### PR TITLE
Address EOL products in scope section

### DIFF
--- a/doc/version_1/040_treesForVulMgmt.md
+++ b/doc/version_1/040_treesForVulMgmt.md
@@ -79,7 +79,11 @@ For example, an organization with a high aversion to change risk might choose to
 
 ## Scope
 
-One important variable in the answers to all the below decision points is scope. There are at least two aspects to scope. One is how the boundaries of the affected system are set. A second is how far forward in time or causal steps one reasons about effects and harms. We put forward recommendations for both of these. However, users of the decision process may want to define different scopes. Users may define a different scope as long as the scope is consistent across decisions, and are credible, explicit, and accessible to all relevant decision makers.
+One important variable in the answers to all the below decision points is scope. There are at least two aspects to scope. One is how the boundaries of the affected system are set. A second is how far forward in time or causal steps one reasons about effects and harms. We put forward recommendations for both of these. 
+
+However, users of the decision process may want to define different scopes. Users may define a different scope as long as the scope is consistent across decisions, and are credible, explicit, and accessible to all relevant decision makers. 
+
+For example, suppliers often decline to support products beyond a declared end-of-life (EOL) date. In those cases, a supplier could reasonably consider vulnerabilities in those products to be out of scope. However, a deployer may still have active instances of EOL products in their infrastructure. It remains appropriate for a deployer to use SSVC to prioritize their response to such situations, since even if there is no fix forthcoming from the supplier it may be possible for the deployer to mitigate or remediate the vulnerability in other ways, up to and including decommissioning the affected system(s).
 
 ### Boundaries of the Affected System
 


### PR DESCRIPTION
Fix #13 

Adds a paragraph to scope giving an example of how suppliers and deployers might have different positions on whether EOL software is in or out of scope.