### PR TITLE
Make Public Safety Impact values consistent throughout

### DIFF
--- a/data/csvs/coord-triage-options.csv
+++ b/data/csvs/coord-triage-options.csv
@@ -1,86 +1,85 @@
 row,Public,Contacted,Report_Credibility,Cardinality,Engagement,Utility,Public_Safety_Impact,Priority
-1,no,yes,no,one,active,laborious,minor,decline
-2,no,yes,no,one,active,laborious,huge,decline
-3,no,yes,no,one,active,efficient,minor,decline
-4,no,yes,no,one,active,efficient,huge,track
-5,no,yes,no,one,active,super effective,minor,decline
-6,no,yes,no,one,active,super effective,huge,track
-7,no,yes,no,one,unresponsive,laborious,minor,decline
-8,no,yes,no,one,unresponsive,laborious,huge,decline
-9,no,yes,no,one,unresponsive,efficient,minor,decline
-10,no,yes,no,one,unresponsive,efficient,huge,track
-11,no,yes,no,one,unresponsive,super effective,minor,decline
-12,no,yes,no,one,unresponsive,super effective,huge,track
-13,no,yes,no,multiple,active,laborious,minor,decline
-14,no,yes,no,multiple,active,laborious,huge,track
-15,no,yes,no,multiple,active,efficient,minor,decline
-16,no,yes,no,multiple,active,efficient,huge,track
-17,no,yes,no,multiple,active,super effective,minor,track
-18,no,yes,no,multiple,active,super effective,huge,coordinate
-19,no,yes,no,multiple,unresponsive,laborious,minor,decline
-20,no,yes,no,multiple,unresponsive,laborious,huge,track
-21,no,yes,no,multiple,unresponsive,efficient,minor,decline
-22,no,yes,no,multiple,unresponsive,efficient,huge,track
-23,no,yes,no,multiple,unresponsive,super effective,minor,track
-24,no,yes,no,multiple,unresponsive,super effective,huge,coordinate
-25,no,yes,yes,one,active,laborious,minor,decline
-26,no,yes,yes,one,active,laborious,huge,decline
-27,no,yes,yes,one,active,efficient,minor,decline
-28,no,yes,yes,one,active,efficient,huge,track
-29,no,yes,yes,one,active,super effective,minor,decline
-30,no,yes,yes,one,active,super effective,huge,track
-31,no,yes,yes,one,unresponsive,laborious,minor,track
-32,no,yes,yes,one,unresponsive,laborious,huge,coordinate
-33,no,yes,yes,one,unresponsive,efficient,minor,coordinate
-34,no,yes,yes,one,unresponsive,efficient,huge,coordinate
-35,no,yes,yes,one,unresponsive,super effective,minor,coordinate
-36,no,yes,yes,one,unresponsive,super effective,huge,coordinate
-37,no,yes,yes,multiple,active,laborious,minor,decline
-38,no,yes,yes,multiple,active,laborious,huge,track
-39,no,yes,yes,multiple,active,efficient,minor,decline
-40,no,yes,yes,multiple,active,efficient,huge,track
-41,no,yes,yes,multiple,active,super effective,minor,coordinate
-42,no,yes,yes,multiple,active,super effective,huge,coordinate
-43,no,yes,yes,multiple,unresponsive,laborious,minor,coordinate
-44,no,yes,yes,multiple,unresponsive,laborious,huge,coordinate
-45,no,yes,yes,multiple,unresponsive,efficient,minor,coordinate
-46,no,yes,yes,multiple,unresponsive,efficient,huge,coordinate
-47,no,yes,yes,multiple,unresponsive,super effective,minor,coordinate
-48,no,yes,yes,multiple,unresponsive,super effective,huge,coordinate
-
-49,yes,yes,no,multiple,active,super effective,huge,coordinate
-50,yes,yes,no,multiple,unresponsive,super effective,huge,coordinate
-51,yes,yes,yes,multiple,active,super effective,huge,coordinate
-52,yes,yes,yes,multiple,unresponsive,super effective,huge,coordinate
-53,yes,no,no,multiple,active,super effective,huge,coordinate
-54,yes,no,no,multiple,unresponsive,super effective,huge,coordinate
-55,yes,no,yes,multiple,active,super effective,huge,coordinate
-56,yes,no,yes,multiple,unresponsive,super effective,huge,coordinate
-57,yes,yes,no,one,active,laborious,minor,decline
-58,yes,yes,no,one,active,efficient,minor,decline
-59,yes,yes,no,one,unresponsive,laborious,minor,decline
-60,yes,yes,no,one,unresponsive,efficient,minor,decline
-61,yes,yes,yes,one,active,laborious,minor,decline
-62,yes,yes,yes,one,active,efficient,minor,decline
-63,yes,yes,yes,one,unresponsive,laborious,minor,decline
-64,yes,yes,yes,one,unresponsive,efficient,minor,decline
-65,yes,no,no,one,active,laborious,minor,decline
-66,yes,no,no,one,active,efficient,minor,decline
-67,yes,no,no,one,unresponsive,laborious,minor,decline
-68,yes,no,no,one,unresponsive,efficient,minor,decline
-69,yes,no,yes,one,active,laborious,minor,decline
-70,yes,no,yes,one,active,efficient,minor,decline
-71,yes,no,yes,one,unresponsive,laborious,minor,decline
-72,yes,no,yes,one,unresponsive,efficient,minor,decline
-73,no,no,no,multiple,active,super effective,huge,coordinate
-74,no,no,no,multiple,unresponsive,super effective,huge,coordinate
-75,no,no,yes,multiple,active,super effective,huge,coordinate
-76,no,no,yes,multiple,unresponsive,super effective,huge,coordinate
-77,no,no,no,one,active,laborious,minor,decline
-78,no,no,no,one,active,efficient,minor,decline
-79,no,no,no,one,unresponsive,laborious,minor,decline
-80,no,no,no,one,unresponsive,efficient,minor,decline
-81,no,no,yes,one,active,laborious,minor,decline
-82,no,no,yes,one,active,efficient,minor,decline
-83,no,no,yes,one,unresponsive,laborious,minor,decline
-84,no,no,yes,one,unresponsive,efficient,minor,decline
+1,no,yes,no,one,active,laborious,minimal,decline
+2,no,yes,no,one,active,laborious,significant,decline
+3,no,yes,no,one,active,efficient,minimal,decline
+4,no,yes,no,one,active,efficient,significant,track
+5,no,yes,no,one,active,super effective,minimal,decline
+6,no,yes,no,one,active,super effective,significant,track
+7,no,yes,no,one,unresponsive,laborious,minimal,decline
+8,no,yes,no,one,unresponsive,laborious,significant,decline
+9,no,yes,no,one,unresponsive,efficient,minimal,decline
+10,no,yes,no,one,unresponsive,efficient,significant,track
+11,no,yes,no,one,unresponsive,super effective,minimal,decline
+12,no,yes,no,one,unresponsive,super effective,significant,track
+13,no,yes,no,multiple,active,laborious,minimal,decline
+14,no,yes,no,multiple,active,laborious,significant,track
+15,no,yes,no,multiple,active,efficient,minimal,decline
+16,no,yes,no,multiple,active,efficient,significant,track
+17,no,yes,no,multiple,active,super effective,minimal,track
+18,no,yes,no,multiple,active,super effective,significant,coordinate
+19,no,yes,no,multiple,unresponsive,laborious,minimal,decline
+20,no,yes,no,multiple,unresponsive,laborious,significant,track
+21,no,yes,no,multiple,unresponsive,efficient,minimal,decline
+22,no,yes,no,multiple,unresponsive,efficient,significant,track
+23,no,yes,no,multiple,unresponsive,super effective,minimal,track
+24,no,yes,no,multiple,unresponsive,super effective,significant,coordinate
+25,no,yes,yes,one,active,laborious,minimal,decline
+26,no,yes,yes,one,active,laborious,significant,decline
+27,no,yes,yes,one,active,efficient,minimal,decline
+28,no,yes,yes,one,active,efficient,significant,track
+29,no,yes,yes,one,active,super effective,minimal,decline
+30,no,yes,yes,one,active,super effective,significant,track
+31,no,yes,yes,one,unresponsive,laborious,minimal,track
+32,no,yes,yes,one,unresponsive,laborious,significant,coordinate
+33,no,yes,yes,one,unresponsive,efficient,minimal,coordinate
+34,no,yes,yes,one,unresponsive,efficient,significant,coordinate
+35,no,yes,yes,one,unresponsive,super effective,minimal,coordinate
+36,no,yes,yes,one,unresponsive,super effective,significant,coordinate
+37,no,yes,yes,multiple,active,laborious,minimal,decline
+38,no,yes,yes,multiple,active,laborious,significant,track
+39,no,yes,yes,multiple,active,efficient,minimal,decline
+40,no,yes,yes,multiple,active,efficient,significant,track
+41,no,yes,yes,multiple,active,super effective,minimal,coordinate
+42,no,yes,yes,multiple,active,super effective,significant,coordinate
+43,no,yes,yes,multiple,unresponsive,laborious,minimal,coordinate
+44,no,yes,yes,multiple,unresponsive,laborious,significant,coordinate
+45,no,yes,yes,multiple,unresponsive,efficient,minimal,coordinate
+46,no,yes,yes,multiple,unresponsive,efficient,significant,coordinate
+47,no,yes,yes,multiple,unresponsive,super effective,minimal,coordinate
+48,no,yes,yes,multiple,unresponsive,super effective,significant,coordinate
+49,yes,yes,no,multiple,active,super effective,significant,coordinate
+50,yes,yes,no,multiple,unresponsive,super effective,significant,coordinate
+51,yes,yes,yes,multiple,active,super effective,significant,coordinate
+52,yes,yes,yes,multiple,unresponsive,super effective,significant,coordinate
+53,yes,no,no,multiple,active,super effective,significant,coordinate
+54,yes,no,no,multiple,unresponsive,super effective,significant,coordinate
+55,yes,no,yes,multiple,active,super effective,significant,coordinate
+56,yes,no,yes,multiple,unresponsive,super effective,significant,coordinate
+57,yes,yes,no,one,active,laborious,minimal,decline
+58,yes,yes,no,one,active,efficient,minimal,decline
+59,yes,yes,no,one,unresponsive,laborious,minimal,decline
+60,yes,yes,no,one,unresponsive,efficient,minimal,decline
+61,yes,yes,yes,one,active,laborious,minimal,decline
+62,yes,yes,yes,one,active,efficient,minimal,decline
+63,yes,yes,yes,one,unresponsive,laborious,minimal,decline
+64,yes,yes,yes,one,unresponsive,efficient,minimal,decline
+65,yes,no,no,one,active,laborious,minimal,decline
+66,yes,no,no,one,active,efficient,minimal,decline
+67,yes,no,no,one,unresponsive,laborious,minimal,decline
+68,yes,no,no,one,unresponsive,efficient,minimal,decline
+69,yes,no,yes,one,active,laborious,minimal,decline
+70,yes,no,yes,one,active,efficient,minimal,decline
+71,yes,no,yes,one,unresponsive,laborious,minimal,decline
+72,yes,no,yes,one,unresponsive,efficient,minimal,decline
+73,no,no,no,multiple,active,super effective,significant,coordinate
+74,no,no,no,multiple,unresponsive,super effective,significant,coordinate
+75,no,no,yes,multiple,active,super effective,significant,coordinate
+76,no,no,yes,multiple,unresponsive,super effective,significant,coordinate
+77,no,no,no,one,active,laborious,minimal,decline
+78,no,no,no,one,active,efficient,minimal,decline
+79,no,no,no,one,unresponsive,laborious,minimal,decline
+80,no,no,no,one,unresponsive,efficient,minimal,decline
+81,no,no,yes,one,active,laborious,minimal,decline
+82,no,no,yes,one,active,efficient,minimal,decline
+83,no,no,yes,one,unresponsive,laborious,minimal,decline
+84,no,no,yes,one,unresponsive,efficient,minimal,decline

--- a/doc/graphics/ssvc_2_coord-triage.tex
+++ b/doc/graphics/ssvc_2_coord-triage.tex
@@ -51,60 +51,60 @@ for tree={s sep*=0.33, l sep=20mm, child anchor=west, anchor=west, grow=east, ca
 [Engagement, rectangle, draw, my label={multiple},
 [Utility, rectangle, draw, my label={unresponsive},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, coordinate, my label={huge} ]
-[, track, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, track, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 ] 
 [Utility, rectangle, draw, my label={active},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, coordinate, my label={huge} ]
-[, track, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, track, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 ] 
 ] 
 [Engagement, rectangle, draw, my label={one},
 [Utility, rectangle, draw, my label={unresponsive},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, decline, my label={huge} ]
-[, decline, my label={minor} ]
+[, decline, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 ] 
 [Utility, rectangle, draw, my label={active},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, decline, my label={huge} ]
-[, decline, my label={minor} ]
+[, decline, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 ] 
 ] 
@@ -113,60 +113,60 @@ for tree={s sep*=0.33, l sep=20mm, child anchor=west, anchor=west, grow=east, ca
 [Engagement, rectangle, draw, my label={multiple},
 [Utility, rectangle, draw, my label={unresponsive},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, coordinate, my label={huge} ]
-[, coordinate, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, coordinate, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, coordinate, my label={huge} ]
-[, coordinate, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, coordinate, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, coordinate, my label={huge} ]
-[, coordinate, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, coordinate, my label={minimal} ]
 ] 
 ] 
 [Utility, rectangle, draw, my label={active},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, coordinate, my label={huge} ]
-[, coordinate, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, coordinate, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 ] 
 ] 
 [Engagement, rectangle, draw, my label={one},
 [Utility, rectangle, draw, my label={unresponsive},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, coordinate, my label={huge} ]
-[, coordinate, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, coordinate, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, coordinate, my label={huge} ]
-[, coordinate, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, coordinate, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, coordinate, my label={huge} ]
-[, track, my label={minor} ]
+[, coordinate, my label={significant} ]
+[, track, my label={minimal} ]
 ] 
 ] 
 [Utility, rectangle, draw, my label={active},
 [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={efficient},
-[, track, my label={huge} ]
-[, decline, my label={minor} ]
+[, track, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 [PublicSafetyImpact, rectangle, draw, my label={laborious},
-[, decline, my label={huge} ]
-[, decline, my label={minor} ]
+[, decline, my label={significant} ]
+[, decline, my label={minimal} ]
 ] 
 ] 
 ] 
@@ -177,7 +177,7 @@ for tree={s sep*=0.33, l sep=20mm, child anchor=west, anchor=west, grow=east, ca
     [Engagement, rectangle, draw, my label={multiple},
      [Utility, rectangle, draw, my label={*},
       [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-       [, coordinate, my label={huge} ] 
+       [, coordinate, my label={significant} ]
       ]
      ]
     ]
@@ -191,7 +191,7 @@ for tree={s sep*=0.33, l sep=20mm, child anchor=west, anchor=west, grow=east, ca
     [Engagement, rectangle, draw, my label={multiple},
      [Utility, rectangle, draw, my label={*},
       [PublicSafetyImpact, rectangle, draw, my label={super-effective},
-       [, coordinate, my label={huge} ] 
+       [, coordinate, my label={significant} ]
       ]
      ]
     ]

--- a/src/enumerate-coord-triage-options.sh
+++ b/src/enumerate-coord-triage-options.sh
@@ -19,7 +19,7 @@ for ReportCredibility in no yes
   do for Cardinality in one multiple
     do for Engagement in active unresponsive
       do for Utility in laborious efficient "super effective"
-        do for PublicSafetyImpact in minor huge
+        do for PublicSafetyImpact in minimal significant
           do echo $i,no,yes,$ReportCredibility,$Cardinality,$Engagement,$Utility,$PublicSafetyImpact, >>$out 
           # for this tree, there is not much variation unless the vul is not already
           # Public and the reported has already tried to contact the vendor/supplier 
@@ -33,7 +33,7 @@ done
 for Contacted in yes no
   do for ReportCredibility in no yes
     do for Engagement in active unresponsive
-      do echo $i,yes,$Contacted,$ReportCredibility,multiple,$Engagement,super effective,huge,coordinate >>$out 
+      do echo $i,yes,$Contacted,$ReportCredibility,multiple,$Engagement,super effective,significant,coordinate >>$out
              i=$(($i+1))
     done
   done
@@ -42,7 +42,7 @@ for Contacted in yes no
   do for ReportCredibility in no yes
     do for Engagement in active unresponsive
       do for Utility in laborious efficient
-        do echo $i,yes,$Contacted,$ReportCredibility,one,$Engagement,$Utility,minor,decline >>$out 
+        do echo $i,yes,$Contacted,$ReportCredibility,one,$Engagement,$Utility,minimal,decline >>$out
              i=$(($i+1))
       done
     done
@@ -52,14 +52,14 @@ done #Decline for other situations where vul is already public
 
 for ReportCredibility in no yes
   do for Engagement in active unresponsive
-    do echo $i,no,no,$ReportCredibility,multiple,$Engagement,super effective,huge,coordinate >>$out 
+    do echo $i,no,no,$ReportCredibility,multiple,$Engagement,super effective,significant,coordinate >>$out
              i=$(($i+1))
   done
 done #exceptions to supplier/vendor not contacted by reporter but will still coordinate
 for ReportCredibility in no yes
   do for Engagement in active unresponsive
     do for Utility in laborious efficient
-      do echo $i,no,no,$ReportCredibility,one,$Engagement,$Utility,minor,decline >>$out 
+      do echo $i,no,no,$ReportCredibility,one,$Engagement,$Utility,minimal,decline >>$out
              i=$(($i+1))
     done
   done

--- a/ssvc-calc/Coordinator-Triage.json
+++ b/ssvc-calc/Coordinator-Triage.json
@@ -239,13 +239,13 @@
             "decision_type": "simple",
             "options": [
 		{
-		    "label": "minor",
+		    "label": "minimal",
 		    "key": "M",
 		    "description": "Any one of the following is observed \"Physical Harm\": Physical discomfort for users of the system OR a minor occupational safety hazard OR reduction in physical system safety margins. \"Environment\": Minor externalities (property damage, environmental damage, etc.) imposed on other parties. \"Financial\": Financial losses, which are not readily absorbable, to multiple persons. \"Psychological\": Emotional or psychological harm, sufficient to be cause for counseling or therapy, to multiple persons."
 		},
 		{
-		    "label": "huge",
-		    "key": "H",
+		    "label": "significant",
+		    "key": "S",
 		    "description": "Any one of the following (or worse) is observed \"Physical Harm\": Physical distress and injuries for users of the system OR a significant occupational safety hazard OR failure of physical system functional capabilities that support safe operation. \"Environment\": Major externalities (property damage, environmental damage, etc.) imposed on other parties. \"Financial\": Financial losses that likely lead to bankruptcy of multiple persons. \"Psychological\": Widespread emotional or psychological harm, sufficient to be cause for counseling or therapy, to populations of people."
 		}
             ],
@@ -281,7 +281,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -291,7 +291,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "decline"
 	},
 	{
@@ -301,7 +301,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -311,7 +311,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -321,7 +321,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -331,7 +331,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -341,7 +341,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -351,7 +351,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "decline"
 	},
 	{
@@ -361,7 +361,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -371,7 +371,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -381,7 +381,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -391,7 +391,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -401,7 +401,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -411,7 +411,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -421,7 +421,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -431,7 +431,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -441,7 +441,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "track"
 	},
 	{
@@ -451,7 +451,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -461,7 +461,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -471,7 +471,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -481,7 +481,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -491,7 +491,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -501,7 +501,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "track"
 	},
 	{
@@ -511,7 +511,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -521,7 +521,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -531,7 +531,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "decline"
 	},
 	{
@@ -541,7 +541,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -551,7 +551,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -561,7 +561,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -571,7 +571,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -581,7 +581,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "track"
 	},
 	{
@@ -591,7 +591,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -601,7 +601,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "coordinate"
 	},
 	{
@@ -611,7 +611,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -621,7 +621,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "coordinate"
 	},
 	{
@@ -631,7 +631,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -641,7 +641,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -651,7 +651,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -661,7 +661,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -671,7 +671,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "track"
 	},
 	{
@@ -681,7 +681,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "coordinate"
 	},
 	{
@@ -691,7 +691,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -701,7 +701,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "coordinate"
 	},
 	{
@@ -711,7 +711,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -721,7 +721,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "coordinate"
 	},
 	{
@@ -731,7 +731,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -741,7 +741,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "coordinate"
 	},
 	{
@@ -751,7 +751,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -761,7 +761,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -771,7 +771,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -781,7 +781,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -791,7 +791,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -801,7 +801,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -811,7 +811,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -821,7 +821,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -831,7 +831,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -841,7 +841,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -851,7 +851,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -861,7 +861,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -871,7 +871,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -881,7 +881,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -891,7 +891,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -901,7 +901,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -911,7 +911,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -921,7 +921,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -931,7 +931,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -941,7 +941,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -951,7 +951,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -961,7 +961,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -971,7 +971,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -981,7 +981,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -991,7 +991,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1001,7 +1001,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -1011,7 +1011,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -1021,7 +1021,7 @@
             "Cardinality": "multiple",
             "Engagement": "active",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -1031,7 +1031,7 @@
             "Cardinality": "multiple",
             "Engagement": "unresponsive",
             "Utility": "super effective",
-            "Public_Safety_Impact": "huge",
+            "Public_Safety_Impact": "significant",
             "Priority": "coordinate"
 	},
 	{
@@ -1041,7 +1041,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1051,7 +1051,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1061,7 +1061,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1071,7 +1071,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1081,7 +1081,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1091,7 +1091,7 @@
             "Cardinality": "one",
             "Engagement": "active",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1101,7 +1101,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "laborious",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	},
 	{
@@ -1111,7 +1111,7 @@
             "Cardinality": "one",
             "Engagement": "unresponsive",
             "Utility": "efficient",
-            "Public_Safety_Impact": "minor",
+            "Public_Safety_Impact": "minimal",
             "Priority": "decline"
 	}
     ],


### PR DESCRIPTION
fixes #266 

Makes Coordinator Triage `.csv`, tree diagram, `.sh`, and `.json` representation consistent with the main document's use of **Minimal** and **Significant** as the values of _Public Safety Impact_ rather than **Minor** and **Huge**.