### PR TITLE
fix typos in json schema descriptions

### DIFF
--- a/data/schema/SSVC_Computed.schema.json
+++ b/data/schema/SSVC_Computed.schema.json
@@ -38,7 +38,7 @@
 	},
 	"version": {
 	    "type": "string",
-	    "description":"Version of the SSVC that was used in this decision.  This version is of the semver format major.minor.patch The major.minor should identify SSVC version being used.  The specific tree being used should be in the patch numbet For example: \"Applier Tree 2.0.3\" would be the identity of the version of SSVC being \"2.0\" and the version of the Applier Tree to be \"3\"."
+	    "description":"Version of the SSVC that was used in this decision.  This version is of the semver format major.minor.patch The major.minor should identify SSVC version being used.  The specific tree being used should be in the patch number For example: \"Applier Tree 2.0.3\" would be the identity of the version of SSVC being \"2.0\" and the version of the Applier Tree to be \"3\"."
 	},
 	"decision_tree": {
 	    "description": "The full decision tree that was used for this SSVC computed score",
@@ -46,7 +46,7 @@
 	},
 	"id": {
 	    "type": "string",
-	    "description": "Identifier for a vulnerbaility could be CVE, CERT/CC VU#, OSV id, Bugtraq etc."
+	    "description": "Identifier for a vulnerability could be CVE, CERT/CC VU#, OSV id, Bugtraq etc."
 	},
 	"decision_tree_url": {
 	    "type": "string",

--- a/data/schema/SSVC_Provision.schema.json
+++ b/data/schema/SSVC_Provision.schema.json
@@ -38,7 +38,7 @@
                                     "type": "string"
                                 },
                                 "key": {
-				    "description": "An optional short \"key\" that identified this \"descision_point\" in SSVC score vector form.  This is one or two letter(s) used in short-form vector representation of the SSVC score.",
+				    "description": "An optional short \"key\" that identified this \"decision_point\" in SSVC score vector form.  This is one or two letter(s) used in short-form vector representation of the SSVC score.",
                                     "type": "string",
                                     "maxLength": 2
                                 },
@@ -67,7 +67,7 @@
                     },
                     "children": {
                         "type": "array",			
-			"description": "The children property is used to identify decision_points that are children of a parent decision_point. The child decision_point(s) should be declared BEFORE the parent decision_point is declared in the array of decision_points.  The children property should NOT be present if the decision_point is not a parent decision_point that is dependant on the the other (child)  decisions.",
+			"description": "The children property is used to identify decision_points that are children of a parent decision_point. The child decision_point(s) should be declared BEFORE the parent decision_point is declared in the array of decision_points.  The children property should NOT be present if the decision_point is not a parent decision_point that is dependent on the the other (child)  decisions.",
 			"items": {
 			    "type": "object",
 			    "properties": {


### PR DESCRIPTION
I fixed some typos in the computed and provision JSON schemas.