### PR TITLE
Add print-site plugin to restore all-in-one page feature

### DIFF
--- a/docs/howto/tree_customization.md
+++ b/docs/howto/tree_customization.md
@@ -1,4 +1,4 @@
-## Tree Construction and Customization Guidance
+# Tree Construction and Customization Guidance
 
 Stakeholders are encouraged to customize the SSVC decision process to their needs.
 Indeed, the first part of SSVC stands for “stakeholder-specific."

--- a/docs/reference/decision_points/mission_impact.md
+++ b/docs/reference/decision_points/mission_impact.md
@@ -1,3 +1,5 @@
+# Mission Impact
+
 !!! note "Mission Impact"
 
     Impact on Mission Essential Functions of the Organization

--- a/docs/reference/decision_points/safety_impact.md
+++ b/docs/reference/decision_points/safety_impact.md
@@ -1,3 +1,5 @@
+# Safety Impact
+
 !!! note "Safety Impact"
 
     Safety Impacts of Affected System Compromise

--- a/docs/reference/decision_points/system_exposure.md
+++ b/docs/reference/decision_points/system_exposure.md
@@ -1,3 +1,5 @@
+# System Exposure
+
 !!! note "System Exposure"
 
     The Accessible Attack Surface of the Affected System or Service

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,8 @@ plugins:
   - table-reader
   - bibtex:
       bib_file: 'doc/md_src_files/sources_ssvc.bib'
+  # NOTE print-site must be last in the list of plugins (see its docs for why)
+  - print-site
 repo_url: 'https://github.com/CERTCC/SSVC'
 repo_name: 'CERTCC/SSVC'
 markdown_extensions:
@@ -158,3 +160,7 @@ extra_javascript:
   - javascripts/tablesort.js
 extra_css:
   - stylesheets/extra.css
+watch:
+  - docs
+  - src
+dev_addr: 127.0.0.1:8001

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-include-markdown-plugin
 mkdocs-table-reader-plugin
 mkdocs-material
 mkdocs-material-extensions
+mkdocs-print-site-plugin


### PR DESCRIPTION
- resolves #331

This PR adds the mkdocs-print-site-plugin 

https://pypi.org/project/mkdocs-print-site-plugin/

Which makes it possible to generate a single-page version of the site like

https://ahouseholder.github.io/SSVC/print_page/

We would need to do some clean up to make it look right, but I think that cleanup is premature at this stage. (If we include this now then decide to roll it back later, it is as simple as removing the `- print-site` line from `mkdocs.yml`.

Also, if this is the way forward, then the following issues will be de facto resolved because it will eliminate our dependency on a custom doc build process.

- resolves #274 
- resolves #213 
- resolves #278 
- resolves #181

