### PR TITLE
Policy Generator tool, first pass

### DIFF
--- a/docs/reference/code/outcomes.md
+++ b/docs/reference/code/outcomes.md
@@ -1,0 +1,5 @@
+# Outcome Values and Outcome Groups
+
+::: ssvc.outcomes.base
+
+::: ssvc.outcomes.groups

--- a/docs/reference/code/policy_generator.md
+++ b/docs/reference/code/policy_generator.md
@@ -1,0 +1,3 @@
+# SSVC Policy Generator Tool
+
+::: ssvc.policy_generator

--- a/docs/reference/code/policy_generator.md
+++ b/docs/reference/code/policy_generator.md
@@ -1,3 +1,9 @@
 # SSVC Policy Generator Tool
 
+The SSVC Policy Generator is a Python object that generates an SSVC decision
+policy (a decision tree) from a set of input parameters.
+
+It is intended to be used as a library, for example within a Jupyter notebook.
+
+
 ::: ssvc.policy_generator

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Value Density: 'reference/decision_points/value_density.md'
     - Code:
         analyze_csv: 'reference/code/analyze_csv.md'
+        policy_generator: 'reference/code/policy_generator.md'
   - Calculator: 'ssvc-calc/index.html'
   - About:
     - Intro: 'about/index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,9 +70,9 @@ nav:
       - Technical Impact: 'reference/decision_points/technical_impact.md'
       - Value Density: 'reference/decision_points/value_density.md'
     - Code:
-        analyze_csv: 'reference/code/analyze_csv.md'
-        policy_generator: 'reference/code/policy_generator.md'
-        outcomes: 'reference/code/outcomes.md'
+        CSV Analyzer: 'reference/code/analyze_csv.md'
+        Policy Generator: 'reference/code/policy_generator.md'
+        Outcomes: 'reference/code/outcomes.md'
   - Calculator: 'ssvc-calc/index.html'
   - About:
     - Intro: 'about/index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - Code:
         analyze_csv: 'reference/code/analyze_csv.md'
         policy_generator: 'reference/code/policy_generator.md'
+        outcomes: 'reference/code/outcomes.md'
   - Calculator: 'ssvc-calc/index.html'
   - About:
     - Intro: 'about/index.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ mkdocstrings
 mkdocstrings-python
 mkdocs-print-site-plugin
 dataclasses-json
-pandas
-scikit-learn
-jsonschema
+pandas~=2.1.2
+scikit-learn~=1.3.2
+jsonschema~=4.19.2
+networkx~=3.1

--- a/src/ssvc/_mixins.py
+++ b/src/ssvc/_mixins.py
@@ -4,6 +4,19 @@ file: _basics
 author: adh
 created_at: 9/20/23 4:51 PM
 """
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -46,6 +59,18 @@ def exclude_if_none(value):
 
 @dataclass_json
 @dataclass(kw_only=True)
+class _Commented:
+    """
+    Mixin class for commented SSVC objects.
+    """
+
+    _comment: Optional[str] = field(
+        default=None, metadata=config(exclude=exclude_if_none)
+    )
+
+
+@dataclass_json
+@dataclass(kw_only=True)
 class _Base:
     """
     Base class for SSVC objects.
@@ -53,9 +78,6 @@ class _Base:
 
     name: str
     description: str
-    _comment: Optional[str] = field(
-        default=None, metadata=config(exclude=exclude_if_none)
-    )
 
 
 def main():

--- a/src/ssvc/decision_points/base.py
+++ b/src/ssvc/decision_points/base.py
@@ -19,7 +19,7 @@ created_at: 9/20/23 10:07 AM
 
 import logging
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Iterable
 
 from dataclasses_json import dataclass_json
 
@@ -54,7 +54,7 @@ class SsvcDecisionPoint(
     Models a single decision point as a list of values.
     """
 
-    values: Tuple[SsvcDecisionPointValue] = ()
+    values: Iterable[SsvcDecisionPointValue] = ()
 
     def __iter__(self):
         """

--- a/src/ssvc/dp_groups/base.py
+++ b/src/ssvc/dp_groups/base.py
@@ -23,6 +23,9 @@ class SsvcDecisionPointGroup(_Base, _Versioned):
     decision_points: Tuple[SsvcDecisionPoint]
 
     def __iter__(self):
+        """
+        Allow iteration over the decision points in the group.
+        """
         return iter(self.decision_points)
 
 
@@ -40,20 +43,13 @@ def get_all_decision_points_from(
         list: A list of SsvcDecisionPoint objects.
     """
     dps = []
-    seen = set()
-
     for group in glist:
         for dp in group.decision_points:
             if dp in dps:
                 # skip duplicates
                 continue
-            key = (dp.name, dp.version)
-            if key in seen:
-                # skip duplicates
-                continue
             # keep non-duplicates
             dps.append(dp)
-            seen.add(key)
 
     return tuple(dps)
 

--- a/src/ssvc/dp_groups/base.py
+++ b/src/ssvc/dp_groups/base.py
@@ -41,6 +41,12 @@ class SsvcDecisionPointGroup(_Base, _Versioned):
         """
         return iter(self.decision_points)
 
+    def __len__(self):
+        """
+        Allow len() to be called on the group.
+        """
+        return len(self.decision_points)
+
 
 def get_all_decision_points_from(
     glist: list[SsvcDecisionPointGroup],

--- a/src/ssvc/dp_groups/base.py
+++ b/src/ssvc/dp_groups/base.py
@@ -4,8 +4,21 @@ file: base
 author: adh
 created_at: 9/20/23 4:47 PM
 """
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Iterable
 
 from dataclasses_json import dataclass_json
 
@@ -20,7 +33,7 @@ class SsvcDecisionPointGroup(_Base, _Versioned):
     Models a group of decision points.
     """
 
-    decision_points: Tuple[SsvcDecisionPoint]
+    decision_points: Iterable[SsvcDecisionPoint]
 
     def __iter__(self):
         """
@@ -31,7 +44,7 @@ class SsvcDecisionPointGroup(_Base, _Versioned):
 
 def get_all_decision_points_from(
     glist: list[SsvcDecisionPointGroup],
-) -> Tuple[SsvcDecisionPoint]:
+) -> Iterable[SsvcDecisionPoint]:
     """
     Given a list of SsvcDecisionPointGroup objects, return a list of all
     the unique SsvcDecisionPoint objects contained in those groups.

--- a/src/ssvc/outcomes/__init__.py
+++ b/src/ssvc/outcomes/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023 Carnegie Mellon University and Contributors.

--- a/src/ssvc/outcomes/base.py
+++ b/src/ssvc/outcomes/base.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""
+Provides outcome group and outcome value classes for SSVC.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from dataclasses_json import dataclass_json
+
+from ssvc._mixins import _Base, _Keyed
+
+
+@dataclass_json
+@dataclass(kw_only=True)
+class OutcomeValue(_Base, _Keyed):
+    """
+    Models a single value option for an SSVC outcome.
+    """
+
+
+@dataclass_json
+@dataclass(kw_only=True)
+class OutcomeGroup(_Base):
+    """
+    Models an outcome group.
+    """
+
+    outcomes: Tuple[OutcomeValue]
+
+    def __iter__(self):
+        """
+        Allow iteration over the outcomes in the group.
+        """
+        return iter(self.outcomes)
+
+    # register all instances

--- a/src/ssvc/outcomes/base.py
+++ b/src/ssvc/outcomes/base.py
@@ -16,7 +16,7 @@ Provides outcome group and outcome value classes for SSVC.
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Iterable
 
 from dataclasses_json import dataclass_json
 
@@ -38,7 +38,7 @@ class OutcomeGroup(_Base):
     Models an outcome group.
     """
 
-    outcomes: Tuple[OutcomeValue]
+    outcomes: Iterable[OutcomeValue]
 
     def __iter__(self):
         """

--- a/src/ssvc/outcomes/base.py
+++ b/src/ssvc/outcomes/base.py
@@ -2,6 +2,19 @@
 """
 Provides outcome group and outcome value classes for SSVC.
 """
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -32,5 +45,11 @@ class OutcomeGroup(_Base):
         Allow iteration over the outcomes in the group.
         """
         return iter(self.outcomes)
+
+    def __len__(self):
+        """
+        Allow len() to be called on the group.
+        """
+        return len(self.outcomes)
 
     # register all instances

--- a/src/ssvc/outcomes/groups.py
+++ b/src/ssvc/outcomes/groups.py
@@ -2,12 +2,25 @@
 """
 Provides a set of outcome groups for use in SSVC.
 """
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 from ssvc.outcomes.base import OutcomeGroup, OutcomeValue
 
 # Note: Outcome Groups must be defined in ascending order.
 
 
-DSIO = OutcomeGroup(
+DSOI = OutcomeGroup(
     name="Defer, Scheduled, Out-of-Cycle, Immediate",
     description="The original SSVC outcome group.",
     outcomes=(

--- a/src/ssvc/outcomes/groups.py
+++ b/src/ssvc/outcomes/groups.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""
+Provides a set of outcome groups for use in SSVC.
+"""
+from ssvc.outcomes.base import OutcomeGroup, OutcomeValue
+
+# Note: Outcome Groups must be defined in ascending order.
+
+
+DSIO = OutcomeGroup(
+    name="Defer, Scheduled, Out-of-Cycle, Immediate",
+    description="The original SSVC outcome group.",
+    outcomes=(
+        OutcomeValue(name="Defer", key="D", description="Defer"),
+        OutcomeValue(name="Scheduled", key="S", description="Scheduled"),
+        OutcomeValue(name="Out-of-Cycle", key="O", description="Out-of-Cycle"),
+        OutcomeValue(name="Immediate", key="I", description="Immediate"),
+    ),
+)
+"""
+The original SSVC outcome group.
+"""
+
+PUBLISH = OutcomeGroup(
+    name="Publish, Do Not Publish",
+    description="The publish outcome group.",
+    outcomes=(
+        OutcomeValue(name="Do Not Publish", key="N", description="Do Not Publish"),
+        OutcomeValue(name="Publish", key="P", description="Publish"),
+    ),
+)
+"""
+The publish outcome group.
+"""
+
+COORDINATE = OutcomeGroup(
+    name="Decline, Track, Coordinate",
+    description="The coordinate outcome group.",
+    outcomes=(
+        OutcomeValue(name="Decline", key="D", description="Decline"),
+        OutcomeValue(name="Track", key="T", description="Track"),
+        OutcomeValue(name="Coordinate", key="C", description="Coordinate"),
+    ),
+)
+"""
+The coordinate outcome group.
+"""
+
+MOSCOW = OutcomeGroup(
+    name="Must, Should, Could, Won't",
+    description="The Moscow outcome group.",
+    outcomes=(
+        OutcomeValue(name="Won't", key="W", description="Won't"),
+        OutcomeValue(name="Could", key="C", description="Could"),
+        OutcomeValue(name="Should", key="S", description="Should"),
+        OutcomeValue(name="Must", key="M", description="Must"),
+    ),
+)
+"""
+The MoSCoW outcome group.
+"""
+
+EISENHOWER = OutcomeGroup(
+    name="Do, Schedule, Delegate, Delete",
+    description="The Eisenhower outcome group.",
+    outcomes=(
+        OutcomeValue(name="Delete", key="D", description="Delete"),
+        OutcomeValue(name="Delegate", key="G", description="Delegate"),
+        OutcomeValue(name="Schedule", key="S", description="Schedule"),
+        OutcomeValue(name="Do", key="O", description="Do"),
+    ),
+)
+"""
+The Eisenhower outcome group.
+"""
+
+
+CVSS = OutcomeGroup(
+    name="CVSS Levels",
+    description="The CVSS outcome group.",
+    outcomes=(
+        OutcomeValue(name="Low", key="L", description="Low"),
+        OutcomeValue(name="Medium", key="M", description="Medium"),
+        OutcomeValue(name="High", key="H", description="High"),
+        OutcomeValue(name="Critical", key="C", description="Critical"),
+    ),
+)
+"""
+The CVSS outcome group.
+"""
+
+YES_NO = OutcomeGroup(
+    name="Yes, No",
+    description="The Yes/No outcome group.",
+    outcomes=(
+        OutcomeValue(name="No", key="N", description="No"),
+        OutcomeValue(name="Yes", key="Y", description="Yes"),
+    ),
+)
+"""
+The Yes/No outcome group.
+"""
+
+VALUE_COMPLEXITY = OutcomeGroup(
+    name="Value, Complexity",
+    description="The Value/Complexity outcome group.",
+    outcomes=(
+        # drop, reconsider later, easy win, do first
+        OutcomeValue(name="Drop", key="D", description="Drop"),
+        OutcomeValue(name="Reconsider Later", key="R", description="Reconsider Later"),
+        OutcomeValue(name="Easy Win", key="E", description="Easy Win"),
+        OutcomeValue(name="Do First", key="F", description="Do First"),
+    ),
+)
+"""
+The Value/Complexity outcome group.
+"""
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ssvc/policy_generator.py
+++ b/src/ssvc/policy_generator.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+"""
+Provides a Policy Generator class for SSVC decision point groups
+"""
+import itertools
+import logging
+from typing import List, Tuple
+
+import networkx as nx
+import pandas as pd
+
+from ssvc.dp_groups.base import SsvcDecisionPointGroup
+from ssvc.outcomes.base import OutcomeGroup
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyGenerator:
+    def __init__(
+        self,
+        dp_group: SsvcDecisionPointGroup = None,
+        outcomes: OutcomeGroup = None,
+        outcome_weights: List[float] = None,
+    ):
+        self.dpg: SsvcDecisionPointGroup = dp_group
+        self.outcomes: OutcomeGroup = outcomes
+        self.policy: pd.DataFrame = None
+        self.G: nx.DiGraph = nx.DiGraph()
+        self.top: Tuple[int] = None
+        self.bottom: Tuple[int] = None
+
+        self._enumerated_vec = None
+
+        if outcome_weights is None:
+            self.outcome_weights = [1.0 / len(outcomes) for _ in outcomes]
+        else:
+            self.outcome_weights = outcome_weights
+        logger.debug(f"Outcome weights: {self.outcome_weights}")
+
+    def __enter__(self) -> "PolicyGenerator":
+        """
+        Set up the policy generator.
+
+        Returns:
+            The policy generator context.
+        """
+        self._setup()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def _setup(self):
+        """
+        Convert the decision point group to a vector representation.
+        """
+
+        self._enumerate_dp_values()
+        self._add_nodes()
+        self._add_edges()
+        self._assign_outcomes()
+        self._validate_paths()
+        self._create_policy()
+
+    def _validate_paths(self):
+        for path in nx.all_simple_paths(self.G, self.bottom, self.top):
+            for start, end in zip(path[:-1], path[1:]):
+                u = self.G.nodes[start]["outcome"]
+                v = self.G.nodes[end]["outcome"]
+                assert u <= v, f"Invalid path: {u} !<= {v} in {path}"
+
+    def _create_policy(self):
+        rows = []
+        for node in self.G.nodes:
+            row = {}
+            for i in range(len(node)):
+                # turn the numerical indexes back into decision point names
+                col1 = f"{self.dpg.decision_points[i].name}"
+                row[col1] = self.dpg.decision_points[i].values[node[i]].name
+                # numerical values
+                col2 = f"idx_{self.dpg.decision_points[i].name}"
+                row[col2] = node[i]
+
+            oc_idx = self.G.nodes[node]["outcome"]
+            row["outcome"] = self.outcomes.outcomes[oc_idx].name
+
+            row["idx_outcome"] = oc_idx
+            rows.append(row)
+
+        self.policy = pd.DataFrame(rows)
+
+    def emit_policy(self):
+        df = self.policy.copy()
+        print_cols = [c for c in df.columns if not c.startswith("idx_")]
+        for c in print_cols:
+            df[c] = df[c].str.lower()
+
+        print(df[print_cols].to_csv(index=False))
+
+    def _assign_outcomes(self):
+        node_count = len(self.G.nodes)
+        outcomes = [outcome.name for outcome in self.outcomes.outcomes]
+        logger.debug(f"Outcomes: {outcomes}")
+
+        layers = list(nx.topological_generations(self.G))
+        logger.debug(f"Layer count: {len(layers)}")
+        logger.debug(f"Layer sizes: {[len(layer) for layer in layers]}")
+
+        outcome_counts = [round(node_count * weight) for weight in self.outcome_weights]
+
+        toposort = list(nx.topological_sort(self.G))
+        logger.debug(f"Toposort: {toposort[:4]}...{toposort[-4:]}")
+
+        outcome_idx = 0
+        assigned_counts = [0 for _ in self.outcomes.outcomes]
+        for node in toposort:
+            # step through the nodes in topological order
+            # and assign outcomes to each node
+            self.G.nodes[node]["outcome"] = outcome_idx
+            assigned_counts[outcome_idx] += 1
+
+            # if we've assigned enough of this outcome, move on to the next outcome
+            if (
+                outcome_idx < (len(self.outcomes.outcomes))
+                and outcome_counts[outcome_idx] <= assigned_counts[outcome_idx]
+            ):
+                outcome_idx += 1
+
+        logger.debug(f"Expected counts: {dict(zip(outcomes,outcome_counts))}")
+        logger.debug(f"Assigned counts: {dict(zip(outcomes,assigned_counts))}")
+
+    def _add_edges(self):
+        # for each node, create an edge to the next node if the next node is strictly greater than the current node
+        for u, v in itertools.product(self.G.nodes, self.G.nodes):
+            if u == v:
+                # don't create an edge from a node to itself
+                continue
+
+            # if the next node has at least one value greater than the current node
+            if all(u[i] <= v[i] for i in range(len(u))):
+                # then create an edge from the current node to the next node
+                self.G.add_edge(u, v)
+
+        # the previous loop creates a much larger graph than we need
+        # so replace it with the transitive reduction of the graph
+        logger.debug(f"Edge count (pre-reduction): {len(self.G.edges)}")
+        self.G = nx.transitive_reduction(self.G)
+        logger.info(f"Edge count: {len(self.G.edges)}")
+
+    def _add_nodes(self):
+        # then get the cartesian product of the values
+        # so [[0,1,2],[0,1],[0,1,2]] becomes
+        # [[0,0,0],[0,0,1],[0,0,2],[0,1,0],[0,1,1],[0,1,2]]
+        vec = self._enumerated_vec
+
+        self.bottom = tuple([0 for _ in vec])
+        self.top = tuple([len(vec) - 1 for vec in vec])
+        logger.debug(f"Top node: {self.top}")
+        logger.debug(f"Bottom node: {self.bottom}")
+
+        # add a node for each cartesian product of the elements of vec
+        for node in itertools.product(*vec):
+            node = tuple(node)
+            self.G.add_node(node)
+
+        node_count = len(self.G.nodes)
+        logger.info(f"Node count: {node_count}")
+        return node_count
+
+    def _enumerate_dp_values(self):
+        # for each decision point in the group, get an enumeration of the values
+        # so [[a,b,c],[d,e],[f,g,h]] becomes [[0,1,2],[0,1],[0,1,2]]
+        vec = []
+        for dp in self.dpg.decision_points:
+            vec.append(tuple(range(len(dp.values))))
+
+        logger.debug(f"Enumerated vector: {vec}")
+
+        self._enumerated_vec = vec
+
+
+def main():
+    from ssvc.decision_points.automatable import AUTOMATABLE_1
+    from ssvc.decision_points.exploitation import EXPLOITATION_1
+    from ssvc.decision_points.human_impact import HUMAN_IMPACT_1
+    from ssvc.decision_points.system_exposure import SYSTEM_EXPOSURE_1_0_1
+    from ssvc.outcomes.groups import DSIO
+
+    # set up logging
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    hdlr = logging.StreamHandler()
+    logger.addHandler(hdlr)
+
+    dpg = SsvcDecisionPointGroup(
+        name="Dummy Decision Point Group",
+        description="Dummy decision point group",
+        version="1.0.0",
+        decision_points=[
+            EXPLOITATION_1,
+            SYSTEM_EXPOSURE_1_0_1,
+            AUTOMATABLE_1,
+            HUMAN_IMPACT_1,
+        ],
+    )
+
+    with PolicyGenerator(
+        dp_group=dpg, outcomes=DSIO, outcome_weights=[0.097, 0.583, 0.278, 0.042]
+    ) as pg:
+        pg.emit_policy()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ssvc/policy_generator.py
+++ b/src/ssvc/policy_generator.py
@@ -261,7 +261,7 @@ def main():
     from ssvc.decision_points.exploitation import EXPLOITATION_1
     from ssvc.decision_points.human_impact import HUMAN_IMPACT_1
     from ssvc.decision_points.system_exposure import SYSTEM_EXPOSURE_1_0_1
-    from ssvc.outcomes.groups import DSIO
+    from ssvc.outcomes.groups import DSOI
 
     # set up logging
     logger = logging.getLogger()
@@ -282,7 +282,7 @@ def main():
     )
 
     with PolicyGenerator(
-        dp_group=dpg, outcomes=DSIO, outcome_weights=[0.097, 0.583, 0.278, 0.042]
+        dp_group=dpg, outcomes=DSOI, outcome_weights=[0.097, 0.583, 0.278, 0.042]
     ) as pg:
         pg.emit_policy()
 

--- a/src/ssvc/policy_generator.py
+++ b/src/ssvc/policy_generator.py
@@ -23,6 +23,7 @@ from typing import List, Tuple
 import networkx as nx
 import pandas as pd
 
+from ssvc import csv_analyzer
 from ssvc.dp_groups.base import SsvcDecisionPointGroup
 from ssvc.outcomes.base import OutcomeGroup
 
@@ -162,16 +163,21 @@ class PolicyGenerator:
 
         self.policy = pd.DataFrame(rows)
 
-    def emit_policy(self) -> None:
-        """
-        Prints the policy to stdout in CSV format.
-        """
+    def clean_policy(self) -> pd.DataFrame:
         df = self.policy.copy()
         print_cols = [c for c in df.columns if not c.startswith("idx_")]
         for c in print_cols:
             df[c] = df[c].str.lower()
 
-        print(df[print_cols].to_csv(index=False))
+        return pd.DataFrame(df[print_cols])
+
+    def emit_policy(self) -> None:
+        """
+        Prints the policy to stdout in CSV format.
+        """
+        df = self.clean_policy()
+
+        print(df.to_csv(index=False))
 
     def _assign_outcomes(self):
         node_count = len(self.G.nodes)
@@ -285,6 +291,12 @@ def main():
         dp_group=dpg, outcomes=DSOI, outcome_weights=[0.097, 0.583, 0.278, 0.042]
     ) as pg:
         pg.emit_policy()
+
+    # check policy against csv_analyzer
+    df = pg.clean_policy()
+    imp = csv_analyzer.drop_col_feature_importance(df, "outcome")
+
+    print(imp)
 
 
 if __name__ == "__main__":

--- a/src/test/test_csv_analyzer.py
+++ b/src/test/test_csv_analyzer.py
@@ -1,3 +1,16 @@
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 import unittest
 
 import pandas as pd
@@ -135,6 +148,27 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(args.csvfile, "foo.csv")
         self.assertEqual(args.outcol, "priority")
         self.assertFalse(args.permutation)
+
+    def test_create_dt_classifier(self):
+        df = pd.DataFrame()
+        target = "outcome"
+
+        # key error when target is not in df.columns
+        self.assertNotIn(target, df.columns)
+        self.assertRaises(KeyError, acsv._create_dt_classifier, df, target)
+
+        df["color"] = [1, 1, 1, 1, 2, 2, 2, 2]
+        df["size"] = [1, 2, 3, 4, 1, 2, 3, 4]
+        df["outcome"] = [1, 1, 1, 1, 2, 2, 2, 2]
+
+        # create_dt_classifier should return a DecisionTreeClassifier object
+        model, x, y = acsv._create_dt_classifier(df, target)
+        self.assertIsInstance(model, acsv.DecisionTreeClassifier)
+        self.assertIsInstance(x, pd.DataFrame)
+        self.assertIsInstance(y, pd.Series)
+
+        self.assertIn("color_", x.columns)
+        self.assertIn("size_", x.columns)
 
 
 if __name__ == "__main__":

--- a/src/test/test_dp_base.py
+++ b/src/test/test_dp_base.py
@@ -96,7 +96,7 @@ class MyTestCase(unittest.TestCase):
         self.assertGreater(len(json), 0)
 
         obj2 = base.SsvcDecisionPoint.from_json(json)
-        self.assertEqual(obj, obj2)
+        self.assertEqual(obj.to_dict(), obj2.to_dict())
 
     def test_dp_to_table(self):
         obj = self.dp

--- a/src/test/test_dp_base.py
+++ b/src/test/test_dp_base.py
@@ -1,9 +1,25 @@
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 import unittest
+
 import ssvc.decision_points.base as base
 
 
 class MyTestCase(unittest.TestCase):
     def setUp(self) -> None:
+        self.original_registry = base.REGISTERED_DECISION_POINTS.copy()
+
         self.value = base.SsvcDecisionPointValue(
             name="foo", key="bar", description="baz"
         )
@@ -16,6 +32,30 @@ class MyTestCase(unittest.TestCase):
             namespace="ns",
             values=(self.value,),
         )
+
+    def tearDown(self) -> None:
+        # restore the original registry
+        base.REGISTERED_DECISION_POINTS = self.original_registry
+
+    def test_registry(self):
+        # just by creating the objects, they should be registered
+        self.assertIn(self.dp, base.REGISTERED_DECISION_POINTS)
+
+        dp2 = base.SsvcDecisionPoint(
+            name="asdfad",
+            key="asdfasdf",
+            description="asdfasdf",
+            version="1.33.1",
+            namespace="asdfasdf",
+            values=(
+                self.value,
+                self.value,
+            ),
+        )
+
+        dp2._comment = "asdfasdfasdf"
+
+        self.assertIn(dp2, base.REGISTERED_DECISION_POINTS)
 
     def test_ssvc_value(self):
         obj = self.value
@@ -57,6 +97,18 @@ class MyTestCase(unittest.TestCase):
 
         obj2 = base.SsvcDecisionPoint.from_json(json)
         self.assertEqual(obj, obj2)
+
+    def test_dp_to_table(self):
+        obj = self.dp
+
+        table = base.dp_to_table(obj)
+
+        self.assertIn(obj.description, table)
+        self.assertIn("Value", table)
+        self.assertIn("Key", table)
+        self.assertIn("Description", table)
+        self.assertIn(obj.name, table)
+        self.assertIn(obj.key, table)
 
 
 if __name__ == "__main__":

--- a/src/test/test_dp_groups.py
+++ b/src/test/test_dp_groups.py
@@ -1,0 +1,77 @@
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import unittest
+
+import ssvc.dp_groups.base as dpg
+from ssvc.decision_points import SsvcDecisionPointValue
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dps = []
+        for i in range(10):
+            dp = dpg.SsvcDecisionPoint(
+                name=f"Decision Point {i}",
+                key=f"DP_{i}",
+                description=f"Description of Decision Point {i}",
+                version="1.0.0",
+                values=(
+                    SsvcDecisionPointValue(name="foo", key="FOO", description="foo"),
+                    SsvcDecisionPointValue(name="bar", key="BAR", description="bar"),
+                    SsvcDecisionPointValue(name="baz", key="BAZ", description="baz"),
+                ),
+            )
+            self.dps.append(dp)
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_iter(self):
+        # add them to a decision point group
+        g = dpg.SsvcDecisionPointGroup(
+            name="Test Group", description="Test Group", decision_points=self.dps
+        )
+
+        self.assertTrue(hasattr(g, "__iter__"))
+
+        # iterate over the group
+        for dp in g:
+            self.assertIn(dp, self.dps)
+
+    def test_len(self):
+        # add them to a decision point group
+        g = dpg.SsvcDecisionPointGroup(
+            name="Test Group", description="Test Group", decision_points=self.dps
+        )
+
+        self.assertEqual(len(self.dps), len(g.decision_points))
+        self.assertEqual(len(self.dps), len(g))
+
+    def test_json_roundtrip(self):
+        # add them to a decision point group
+        g = dpg.SsvcDecisionPointGroup(
+            name="Test Group", description="Test Group", decision_points=self.dps
+        )
+
+        # serialize the group to json
+        g_json = g.to_json()
+
+        # deserialize the json to a new group
+        g2 = dpg.SsvcDecisionPointGroup.from_json(g_json)
+        # assert that the new group is the same as the old group
+        self.assertEqual(g.to_dict(), g2.to_dict())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/test_outcomes.py
+++ b/src/test/test_outcomes.py
@@ -1,0 +1,52 @@
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import unittest
+
+from ssvc.outcomes.base import OutcomeGroup, OutcomeValue
+
+ALPHABET = "abcdefghijklmnopqrstuvwxyz"
+
+
+class MyTestCase(unittest.TestCase):
+    def test_outcome_value(self):
+        for x in ALPHABET:
+            ov = OutcomeValue(key=x, name=x, description=x)
+            self.assertEqual(ov.key, x)
+            self.assertEqual(ov.name, x)
+            self.assertEqual(ov.description, x)
+
+    def test_outcome_group(self):
+        ALPHABET
+
+        values = []
+        for x in ALPHABET:
+            values.append(OutcomeValue(key=x, name=x, description=x))
+
+        og = OutcomeGroup(
+            name="og", description="an outcome group", outcomes=tuple(values)
+        )
+
+        self.assertEqual(og.name, "og")
+        self.assertEqual(og.description, "an outcome group")
+
+        self.assertEqual(len(og), len(ALPHABET))
+
+        for i, letter in enumerate(ALPHABET):
+            self.assertEqual(og.outcomes[i].key, letter)
+            self.assertEqual(og.outcomes[i].name, letter)
+            self.assertEqual(og.outcomes[i].description, letter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/test_policy_generator.py
+++ b/src/test/test_policy_generator.py
@@ -1,0 +1,291 @@
+#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import unittest
+from collections import Counter
+from itertools import product
+
+import networkx as nx
+import pandas as pd
+
+from ssvc.decision_points import SsvcDecisionPoint, SsvcDecisionPointValue
+from ssvc.dp_groups.base import SsvcDecisionPointGroup
+from ssvc.outcomes.base import OutcomeGroup, OutcomeValue
+from ssvc.policy_generator import PolicyGenerator
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.og_names = ["Never", "Someday", "Today", "Now"]
+        self.dp_values = ["Yes", "No"]
+        self.dp_names = ["Who", "What", "When", "Where"]
+
+        self.og = OutcomeGroup(
+            name="test",
+            description="test",
+            outcomes=[
+                OutcomeValue(key=c, name=c, description=c) for c in self.og_names
+            ],
+        )
+        self.dpg = SsvcDecisionPointGroup(
+            name="test",
+            description="test",
+            decision_points=[
+                SsvcDecisionPoint(
+                    name=c,
+                    description=c,
+                    key=c,
+                    values=[
+                        SsvcDecisionPointValue(name=v, key=v, description=v)
+                        for v in self.dp_values
+                    ],
+                )
+                for c in self.dp_names
+            ],
+        )
+
+    def test_pg_init(self):
+        self.assertEqual(4, len(self.dpg.decision_points))
+        self.assertEqual(4, len(self.og.outcomes))
+
+        pg = PolicyGenerator(dp_group=self.dpg, outcomes=self.og)
+        for w in pg.outcome_weights:
+            self.assertEqual(0.25, w)
+
+        self.assertIsInstance(
+            pg.G,
+            nx.DiGraph,
+        )
+        self.assertIsNone(pg.policy)
+        self.assertIsNone(pg.top)
+        self.assertIsNone(pg.bottom)
+
+    def test_pg_context(self):
+        with PolicyGenerator(dp_group=self.dpg, outcomes=self.og) as pg:
+            self.assertIsInstance(
+                pg.G,
+                nx.DiGraph,
+            )
+            self.assertIsNotNone(pg.policy)
+            self.assertIsNotNone(pg.top)
+            self.assertIsNotNone(pg.bottom)
+
+    def test_enumerate_dp_values(self):
+        pg = PolicyGenerator(dp_group=self.dpg, outcomes=self.og)
+
+        self.assertIsNone(pg._enumerated_vec)
+
+        pg._enumerate_dp_values()
+        self.assertEqual(4, len(pg._enumerated_vec))
+
+        for t in pg._enumerated_vec:
+            self.assertEqual(2, len(t))
+            self.assertEqual((0, 1), t)
+
+    def test_add_nodes(self):
+        pg = PolicyGenerator(dp_group=self.dpg, outcomes=self.og)
+        pg._enumerated_vec = [(0, 1), (0, 1, 2), (0, 1), (0, 1, 2, 3)]
+
+        self.assertIsNone(pg.bottom)
+        self.assertIsNone(pg.top)
+        self.assertEqual(0, len(pg.G.nodes))
+
+        pg._add_nodes()
+
+        prod = 1
+        for t in pg._enumerated_vec:
+            prod *= len(t)
+
+        self.assertEqual(prod, len(pg.G.nodes))
+
+        self.assertEqual((0, 0, 0, 0), pg.bottom)
+        self.assertEqual((1, 2, 1, 3), pg.top)
+
+        self.assertIn(pg.bottom, pg.G.nodes)
+        self.assertIn(pg.top, pg.G.nodes)
+
+        for i in range(2):
+            for j in range(3):
+                for k in range(2):
+                    for l in range(4):
+                        self.assertIn((i, j, k, l), pg.G.nodes)
+
+        self.assertNotIn((2, 0, 0, 0), pg.G.nodes)
+        self.assertNotIn((0, 3, 0, 0), pg.G.nodes)
+        self.assertNotIn((0, 0, 2, 0), pg.G.nodes)
+        self.assertNotIn((0, 0, 0, 4), pg.G.nodes)
+
+    def test_add_edges(self):
+        pg = PolicyGenerator(dp_group=self.dpg, outcomes=self.og)
+        for i, j, k in product(range(2), range(3), range(2)):
+            pg.G.add_node((i, j, k))
+
+        self.assertEqual(0, len(pg.G.edges))
+
+        pg._add_edges()
+
+        expect_edges = [
+            ((0, 0, 0), (1, 0, 0)),
+            ((0, 0, 0), (0, 1, 0)),
+            ((0, 0, 0), (0, 0, 1)),
+            ((0, 0, 1), (1, 0, 1)),
+            ((0, 0, 1), (0, 1, 1)),
+            ((0, 1, 0), (1, 1, 0)),
+            ((0, 1, 0), (0, 2, 0)),
+            ((0, 1, 0), (0, 1, 1)),
+            ((0, 1, 1), (0, 2, 1)),
+            ((0, 1, 1), (1, 1, 1)),
+            ((0, 2, 0), (0, 2, 1)),
+            ((0, 2, 0), (1, 2, 0)),
+            ((0, 2, 1), (1, 2, 1)),
+            ((1, 0, 0), (1, 0, 1)),
+            ((1, 0, 0), (1, 1, 0)),
+            ((1, 0, 1), (1, 1, 1)),
+            ((1, 1, 0), (1, 1, 1)),
+            ((1, 1, 0), (1, 2, 0)),
+            ((1, 1, 1), (1, 2, 1)),
+            ((1, 2, 0), (1, 2, 1)),
+        ]
+        self.assertEqual(len(expect_edges), len(pg.G.edges))
+
+        for u, v in expect_edges:
+            self.assertIn(u, pg.G.nodes)
+            self.assertIn(v, pg.G.nodes)
+            self.assertIn((u, v), pg.G.edges)
+
+    def test_assign_outcomes(self):
+        pg = PolicyGenerator(dp_group=self.dpg, outcomes=self.og)
+        pg._enumerate_dp_values()
+        pg._add_nodes()
+        pg._add_edges()
+
+        self.assertEqual(16, len(pg.G.nodes))
+        self.assertEqual(32, len(pg.G.edges))
+
+        for node, data in pg.G.nodes.items():
+            self.assertNotIn("outcome", data)
+
+        pg._assign_outcomes()
+
+        outcomes = []
+        for node, data in pg.G.nodes.items():
+            self.assertIn("outcome", data)
+            outcomes.append(data["outcome"])
+
+        # count outcomes
+        counts = Counter(outcomes)
+        self.assertEqual(len(self.og), len(counts))
+
+        # they should be evenly distributed
+        self.assertTrue(all([v == 4 for v in counts.values()]))
+
+    def test_assign_weighted_outcomes(self):
+        pg = PolicyGenerator(
+            dp_group=self.dpg,
+            outcomes=self.og,
+            outcome_weights=[0.5, 0.25, 0.125, 0.125],
+        )
+        pg._enumerate_dp_values()
+        pg._add_nodes()
+        pg._add_edges()
+
+        self.assertEqual(16, len(pg.G.nodes))
+        self.assertEqual(32, len(pg.G.edges))
+
+        for node, data in pg.G.nodes.items():
+            self.assertNotIn("outcome", data)
+
+        pg._assign_outcomes()
+
+        outcomes = []
+        for node, data in pg.G.nodes.items():
+            self.assertIn("outcome", data)
+            outcomes.append(data["outcome"])
+
+        # count outcomes
+        counts = Counter(outcomes)
+        self.assertEqual(len(self.og), len(counts))
+
+        # they should be evenly distributed
+        self.assertEqual({0: 8, 1: 4, 2: 2, 3: 2}, counts)
+
+    def test_emit_policy(self):
+        with PolicyGenerator(dp_group=self.dpg, outcomes=self.og) as pg:
+            # capture stdout
+            import io
+            import contextlib
+
+            f = io.StringIO()
+            with contextlib.redirect_stdout(f):
+                pg.emit_policy()
+
+            stdout = f.getvalue()
+
+            for dpg in pg.dpg.decision_points:
+                self.assertIn(dpg.name, stdout)
+            for og in pg.outcomes.outcomes:
+                self.assertIn(og.name.lower(), stdout)
+
+    def test_create_policy(self):
+        pg = PolicyGenerator(
+            dp_group=self.dpg,
+            outcomes=self.og,
+            outcome_weights=[0.5, 0.25, 0.125, 0.125],
+        )
+        pg._enumerate_dp_values()
+        pg._add_nodes()
+        pg._add_edges()
+        pg._assign_outcomes()
+        pg._validate_paths()
+
+        self.assertIsNone(pg.policy)
+
+        pg._create_policy()
+
+        self.assertIsNotNone(pg.policy)
+        self.assertIsInstance(pg.policy, pd.DataFrame)
+        self.assertEqual(16, len(pg.policy))
+
+        for c in self.dp_names:
+            self.assertIn(c, pg.policy.columns)
+            self.assertIn(f"idx_{c}", pg.policy.columns)
+
+        self.assertIn("outcome", pg.policy.columns)
+        self.assertIn("idx_outcome", pg.policy.columns)
+
+        for outcome in self.og_names:
+            self.assertIn(outcome, pg.policy.outcome.values)
+
+    def test_validate_paths(self):
+        pg = PolicyGenerator(
+            dp_group=self.dpg,
+            outcomes=self.og,
+            outcome_weights=[0.5, 0.25, 0.125, 0.125],
+        )
+        pg._enumerate_dp_values()
+        pg._add_nodes()
+        pg._add_edges()
+        pg._assign_outcomes()
+
+        # should work fine and return None
+        self.assertIsNone(pg._validate_paths())
+
+        # unless we add a bad outcome value
+        pg.G.nodes[(0, 0, 0, 0)]["outcome"] = 5
+
+        with self.assertRaises(ValueError):
+            pg._validate_paths()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR contains a python class that generates an SSVC decision policy (aka a "tree") that fully enumerates a set of decision points and their values, and assigns an outcome to each input value tuple. It does so by 

- constructing a partial order over all the input value tuples
- generating a topological sort over the resulting partial order
- assigning outcomes according to a set of provided weights
- emitting a CSV that replicates the format we've previously used to represent decision policies
- (one column for each decision point, plus an outcome column filled in with the assignments made)

If you run `policy_generator.py` directly, it outputs a policy that's rather close to the Deployer 2.1 tree.

At this point, my goal is to get the module in place with this PR. 

We will need to figure out what the UI is for it, and how to make it easier to use. Right now, you have to write python code to use it, an example of which is provided in `ssvc.policy_generator.main`, but it can probably be made easier to use. One usability issue I can see coming soon is how someone figures out which decision point (and version) to use as input, and how they represent their outcome set. My preference would be to create a separate issue to come back to the CLI side of this tool in the future.  For now, I think it's usable enough for someone comfortable with some light coding-by-example, such as a Jupyter notebook user. I created a separate issue to capture the UI followup task (#366) .

One notable addition in this PR is the creation of `src/ssvc/outcomes/base.py`, which contains a python representation of an `OutcomeGroup` and `OutcomeValues`, and `src/ssvc/outcomes/groups.py` which provides a variety of examples thereof. I think we discussed _not_ versioning outcome sets (I called them _outcome groups_ which have _outcome values_ here but if there's a preference to rename them simply _outcomes_ with _outcome values_, that's an easy change to make.)  

This PR
- resolves #336 
- resolves #337 
- partially addresses (by modeling the outcome set only) #335

I included #337 and #335 because they were good exercise for building `OutcomeGroup` objects.
