### PR TITLE
Add build steps to python-app.yml

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,13 +34,12 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-# stop here for now because we don't have a build step yet
-#    - name: Build
-#      run: |
-#        python -m build
-#    - name: Upload Artifacts
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ssvc
-#        path: dist/ssvc-*.tar.gz
-#        retention-days: 14
+   - name: Build
+     run: |
+       python -m build src
+   - name: Upload Artifacts
+     uses: actions/upload-artifact@v3
+     with:
+       name: ssvc
+       path: src/dist/ssvc-*.tar.gz
+       retention-days: 14

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,12 +34,12 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-   - name: Build
-     run: |
-       python -m build src
-   - name: Upload Artifacts
-     uses: actions/upload-artifact@v3
-     with:
-       name: ssvc
-       path: src/dist/ssvc-*.tar.gz
-       retention-days: 14
+    - name: Build
+      run: |
+        python -m build src
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ssvc
+        path: src/dist/ssvc-*.tar.gz
+        retention-days: 14


### PR DESCRIPTION
Now that we have a pyproject.toml, we can verify that the build process works too, and upload artifacts from each run

Artifact retention is set to 14 days