### PR TITLE
Fix policygenerator slowness

### DIFF
--- a/src/ssvc/policy_generator.py
+++ b/src/ssvc/policy_generator.py
@@ -49,6 +49,7 @@ class PolicyGenerator:
         dp_group: SsvcDecisionPointGroup = None,
         outcomes: OutcomeGroup = None,
         outcome_weights: List[float] = None,
+        validate: bool = False,
     ):
         """
         Create a policy generator.
@@ -98,6 +99,7 @@ class PolicyGenerator:
         self.bottom: Tuple[int] = None
 
         self._enumerated_vec = None
+        self._check_valid_paths = validate
 
     def __enter__(self) -> "PolicyGenerator":
         """
@@ -145,7 +147,8 @@ class PolicyGenerator:
         self._add_nodes()
         self._add_edges()
         self._assign_outcomes()
-        self._validate_paths()
+        if self._check_valid_paths:
+            self._validate_paths()
         self._create_policy()
 
     def _validate_paths(self):


### PR DESCRIPTION
PolicyGenerator's internal checking of all paths is overzealous when the graph of input states gets large, which it can do very easily with just a few decision points. The resulting list of paths in nx.all_simple_paths grows very rapidly, which causes the whole thing to slow down if this feature is activated. This PR retains the option to do the validation if desired by setting the `validate=True` option when a PolicyGenerator object is created. But the default behavior is now to not look at every path. This should be ok, because the way we're creating the graph as the transient reduction of a graph that only adds edges where needed should be sufficient to ensure that we're not going to get any bogus paths anyway. 