### PR TITLE
Add grid to homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,58 @@
 # Stakeholder-Specific Vulnerability Categorization
 
+SSVC stands for A Stakeholder-Specific Vulnerability Categorization. 
+It is a methodology for prioritizing vulnerabilities based on the needs of the stakeholders involved in the vulnerability management process.
+SSVC is designed to be used by any stakeholder in the vulnerability management process, including finders, vendors, coordinators, deployers, and others.
+
+
+
+{== TODO remove this warning when the site is ready ==}
 !!! warning "Work in Progress"
 
     This website is a work in progress.
     While it is intended to eventually be the official documentation for SSVC, it is not yet complete.
     For the latest version of SSVC documentation, see the [GitHub repository](https://github.com/CERTCC/SSVC).
+
+## Where to go from here
+
+We have organized the SSVC documentation into four main sections:
+
+<div class="grid cards" markdown>
+
+- :material-television-shimmer:{ .lg .middle } __Get Started with SSVC__
+
+    ---
+
+    Get started learning about SSVC and how it can help you prioritize vulnerabilities.
+    This section is intended for people who are new to SSVC.
+
+    [:octicons-arrow-right-24: Learning SSVC](tutorials)
+
+- :fontawesome-solid-book:{ .lg .middle } __Learn More about SSVC__
+
+    ---
+
+    Dig deeper to understand the SSVC methodology and how it works.
+    This section is intended for people who are already familiar with SSVC and want to learn more.
+
+    [:octicons-arrow-right-24: Understanding SSVC](topics)
+
+- :material-clipboard-check:{ .lg .middle } __SSVC How To__
+
+    ---
+
+    Start using SSVC in your organization today with step-by-step instructions.
+    This section is intended for people who are already familiar with SSVC and want to start using it.
+
+    [:octicons-arrow-right-24: SSVC How To](howto)
+
+- :material-book-open-page-variant:{ .lg .middle } __SSVC Reference__
+
+    ---
+
+    Reference documentation for SSVC.
+    This section is intended for people who are already familiar with SSVC and want to look up specific details.
+
+    [:octicons-arrow-right-24: Reference](reference)
+
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,8 +130,8 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ mkdocs
 mkdocs-bibtex
 mkdocs-include-markdown-plugin
 mkdocs-table-reader-plugin
-mkdocs-material
+mkdocs-material~=9.5.4
 mkdocs-material-extensions
 mkdocstrings
 mkdocstrings-python


### PR DESCRIPTION
Currently staged at https://certcc.github.io/SSVC-staging/

This PR adds:

- intro paragraph on site home page
- a 4x4 grid to direct folks from the home page to the various sections of the site
- upgrades mkdocs-material to the latest release
- fixes a deprecation warning about obsolete mkdocs extensions