### PR TITLE
Add GH actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      


### PR DESCRIPTION
It's useful to have dependabot keep our github actions up to date.

This is already working in https://github.com/CERTCC/Vultron/blob/main/.github/dependabot.yml