### PR TITLE
Add acuity_ramp.md to HowTo section

### DIFF
--- a/docs/howto/acuity_ramp.md
+++ b/docs/howto/acuity_ramp.md
@@ -1,0 +1,105 @@
+# Acuity Ramp
+
+!!! question inline end "Why _Acuity_? Isn't this a _Maturity_ Model?"
+
+    The _acuity ramp_ concept is similar to the idea of a _maturity model_, but the term _maturity_ carries a sort of
+    moral bias in the sense that it has an implied "good" direction from "immature" to "mature". 
+
+    _Acuity_ has a more neutral connotation, and represents the ability to perceive the world in more detail. 
+    In our usage, _Acuity_ as a dimension is more akin to the idea of resolution in the imagery/photography sense.
+
+    We prefer to avoid burdening the language with an implication of deficiency should an SSVC stakeholder choose to build
+    their decision process using a lower resolution decision point over a higher resolution one, assuming that the lower
+    resolution decision point provides an _appropriate_ resolution for the decision in question.
+
+An SSVC _acuity ramp_ is a concept that describes a series of decision functions that are increasingly more detailed and
+complex while addressing the same decision. The idea is that a decisionmaker can start with a simple decision model and
+then, as they become more capable of gathering and analyzing data and understanding their environment, they can move to
+a more complex decision model.
+
+In Cybersecurity Threat and Vulnerability analysis, as with most decision-making processes, the more information you
+have (up to a point of diminishing returns), the better your decision will be.
+However, gathering information comes at a cost, and there are always trade-offs to be made.
+There are many good reasons that decisionmakers might choose to use a lower resolution indicator that is readily 
+available over a higher resolution indicator that comes at a high cost in terms of time, money, or effort.
+
+## An Acuity Ramp in Action
+
+The _acuity ramp_ idea is a way to show how a stakeholder could "grow into" their desired decision function as their
+data collection and analysis capabilities increase. We demonstrate this with the following example.
+
+!!! example "An Acuity Ramp for a Growing System Deployer Organization"
+
+    A system deployer organization with few initial resources might start with a simple decision model that only includes a custom
+    `IN_KEV` decision point. The `IN_KEV` decision point would be a simple binary indicator of whether a vulnerability
+    has been added to CISA's [Known Exploited Vulnerabilities](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+    ([KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)) catalog. Because this information is free,
+    publicly available, and because it is a simple binary indicator, it is easy to gather and analyze even for a very
+    small organization.
+
+    The following table shows how the organization might expand their decision model as they grow in capability.
+    
+    | Acutiy Level | Tree |
+    | --- | --- |
+    | 1 | ```[IN_KEV]``` |
+    | 2 | ```[EXPLOITATION_1]``` |
+    | 3 | ```[EXPLOITATION_1, SYSTEM_EXPOSURE_1_0_1]``` |
+    | 4 | ```[EXPLOITATION_1, SYSTEM_EXPOSURE_1_0_1, AUTOMATABLE_2]``` |
+    | 5 | ```[EXPLOITATION_1, SYSTEM_EXPOSURE_1_0_1, AUTOMATABLE_2, MISSION_IMPACT_2, SAFETY_IMPACT_1]```
+
+    !!! tip "Acuity Levels are Stakeholder-Specific" 
+
+        This example is demonstrating the _concept_ of _acuity levels_ in SSVC adoption. We are specifically
+        _not_ saying that there are 5 levels of acuity in SSVC; in principle this concept could be applied to any number
+        of levels (including just one). In practice, the number of levels necessary would be a stakeholder-specific implementation choice, so 
+        there is no inherent meaning to the "Acuity Levels" shown here outside the context of this example.
+    
+    The remainder of this example shows one path the organization might take to grow their decision model
+    according to the table above.
+
+    ### Improved Exploit Awareness (Acuity Level 2)
+
+    As the organization becomes more capable of gathering and analyzing data, they might start collecting their own
+    data on exploitation, allowing them to move to a more complex decision tree that replaces the binary `IN_KEV` 
+    decision point with the trinary `EXPLOITATION_1` decision point.
+
+    {% include-markdown "../_generated/decision_points/exploitation_1_0_0.md" %}
+
+    ### Improved Asset Management (Acuity Level 3)
+
+    As they continue to develop their internal asset management capabilities, they might find they have enough
+    asset data to reflect the degree to which a system is exposed to the internet, allowing them to 
+    incorporate the `SYSTEM_EXPOSURE_1_0_1` decision point into their decision model.
+
+    {% include-markdown "../_generated/decision_points/system_exposure_1_0_1.md" %}
+
+    ### Improved Threat and Vulnerability Analysis (Acuity Level 4)
+
+    Over time, the organization's threat and vulnerability analysis capabilities might reach a point where they can
+    begin to collect data on the degree to which a vulnerability is automatable, allowing them to incorporate the
+    `AUTOMATABLE_1` decision point into their decision model.
+
+    {% include-markdown "../_generated/decision_points/automatable_2_0_0.md" %}
+
+    ### Improved Mission and Safety Impact Understanding (Acuity Level 5)
+
+    Now that the deployer organization has been at this for a while, they might have a better understanding of the
+    degree to which a vulnerability impacts both their mission and public safety, allowing them to incorporate the
+    `MISSION_IMPACT_2` and `SAFETY_IMPACT_1` decision points into their decision model.
+
+    {% include-markdown "../_generated/decision_points/mission_impact_2_0_0.md" %}
+    {% include-markdown "../_generated/decision_points/safety_impact_1_0_0.md" %}
+
+    In this way, the organization can grow into a more complex decision model as their understanding and capabilities improve.
+
+
+## Conclusion
+
+The example above is just a single illustration of the _acuity ramp_ concept. There are many other ways that an
+organization might evolve their decision model from a simple starting point toward a more complex decision model for 
+any particular decision. 
+
+The _acuity ramp_ concept is a way to show how a stakeholder could "grow into" their desired decision function as their
+data collection and analysis capabilities improve. It is a way to show how a decision model can be adapted to the
+context of the decisionmaker, and how the decisionmaker can make trade-offs between the cost of gathering information
+and the quality of the decision they are able to make.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Use & Respond: 'howto/bootstrap/use.md'
       - Summary: 'howto/bootstrap/summary.md'
     - Customizing SSVC: 'howto/tree_customization.md'
+    - Acuity Ramp: 'howto/acuity_ramp.md'
     - SSVC and Asset Management: 'howto/asset_management.md'
 
   - Reference:


### PR DESCRIPTION
- resolves #315 

Adds an Acuity Ramp explainer to the HowTo section based on the discussion in #315.

I'm including screenshots of the rendering below since the markdown uses includes that make the content a bit more robust than it appears in the text.
Some of the screencaps cut off a few lines here and there, but this isn't intended to be a review of the content of the decision point tables, just a demo of what the center column of the rendered page is going to look like.

<img width="200" alt="Screenshot 2024-02-02 at 3 33 16 PM" src="https://github.com/CERTCC/SSVC/assets/2594236/10144099-2f0f-4194-8dae-ef01b970060a">
<img width="200" alt="Screenshot 2024-02-02 at 3 33 29 PM" src="https://github.com/CERTCC/SSVC/assets/2594236/3c074f4c-99f7-4938-8f32-dcb5315be3a6">
<img width="200" alt="Screenshot 2024-02-02 at 3 33 43 PM" src="https://github.com/CERTCC/SSVC/assets/2594236/6af3af55-3cda-4d88-a93c-4923c8367031">
<img width="200" alt="Screenshot 2024-02-02 at 3 33 47 PM" src="https://github.com/CERTCC/SSVC/assets/2594236/ce4e97ca-70d3-4bd7-8c90-199764dba7c5">
<img width="200" alt="Screenshot 2024-02-02 at 3 33 52 PM" src="https://github.com/CERTCC/SSVC/assets/2594236/259c4be5-2197-4106-ac1d-d8be7fb596a2">
