### PR TITLE
Remove abbreviated format from docs

### DIFF
--- a/docs/howto/communicating_results.md
+++ b/docs/howto/communicating_results.md
@@ -14,59 +14,9 @@ This section discusses the situation where one stakeholder, usually a supplier o
 
 ## Communication Formats
 
-We recommend two structured communication formats, abbreviated and full.
-The goal of the abbreviated format is to fill a need for providing identifying information about a vulnerability or decision in charts, graphs, and tables. Therefore, the abbreviated format is not designed to stand alone.
-The goal of the full format is to capture all the context and details about a decision or work item in a clear and machine-readable way.
+We recommend a JSON format for communicating SSVC information about a specific vulnerability.
+The goal of this format is to capture all the context and details about a decision or work item in a clear and machine-readable way.
 
-### Abbreviated Format
-
-SSVC abbreviated form borrows directly from the CVSS “vector string” notation.
-Since the purpose of the abbreviated form is to provide labels for charts and graphics, it does not stand alone.
-The basic format for SSVC is:
-```
-SSVC/(version)/(decision point):(value)[/decision point:value[/decision point:value[...]]][/time]/
-```
-Where `version` is `v2` if it is based on this current version of the SSVC.
-The term `decision point` is one or two letters derived from the name of the decision point as follows:
- - Start with the decision point name as given in [Likely Decision Points and Relevant Data](#likely-decision-points-and-relevant-data).
- - Remove any text in parentheses (and the parentheses themselves).
- - Remove the word “Impact” if it is part of the name.
- - Create an initialism from remaining title-case words (ignore “of,” etc.), taking only the first two words.
- - The first letter of the initialism is upper case; if there is a second letter, then it is lower case.
- - Verify that the initialism is unique among decision points in the version of SSVC. If two initialisms collide, sort their source names equivalent to `LC_ALL=C sort`. The name that sorts first keeps the initialism for which there is a collision. Set the second letter of the initialism to the first character in the name that resolves the collision. If the names were `Threat` and `Threshold`, `T` would be `Threat` and `Ts` would be `Threshold`. We make an effort to design SSVC without such collisions.
-
-For example, [*Technical Impact*](#technical-impact) becomes `T` and [*Public Safety Impact*](#public-safety-impact) becomes `Ps`.
-
-The term `value` is a statement of the value or possible values of the decision point that precedes it and to which it is connected by a colon (`:`).
-Similar to `decision point`, `value` should be made up of one or two letters derived from the name of the decision value in the section for its associated decision point.
-For example [MEF support crippled](#mission-impact) becomes `Ms` and [efficient](#utility) becomes `E`.
-The process is the same as above except that labels for a `value` do not need to be unique to the SSVC version, just unique to the associated `decision point`.
-
-The character `/` separates decision-point:value pairs.
-As many pairs should be provided in the abbreviated form as are required to communicate the desired information about the vulnerability or work item.
-A vector must contain at least one decision-point:value pair.
-The ordering of the pairs should be sorted alphabetically from A to Z by the ASCII characters representing the decision points.
-A trailing `/` is used to close the string.
-
-The vector is not tied to a specific decision tree.
-It is meant to communicate information in a condensed form.
-If priority labels (*defer*, etc.) are connected to a vector, then the decision tree used to reach those decisions should generally be noted.
-However, for complex communication, machine-to-machine communication, or long-term storage of SSVC data, the JSON format and schema should be used.
-
-The optional parameter `time` is the date and time of the SSVCv2 record creation as represented in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339). This is a subset of the date format also commonly known as ISO8601 format.
-
-Based on this, an example string could be:
-```
-SSVCv2/Ps:M/T:T/U:E/2018-11-13T20:20:00Z/
-```
-For a vulnerability with [minimal](#public-safety-impact) [*Public Safety Impact*](#public-safety-impact), [total](#technical-impact) [*Technical Impact*](#technical-impact), and [efficient](#utility) [*Utility*](#utility), which was evaluated on Nov 13,2018 at 8:20 PM UTC.
-
-While these abbreviated format vectors can be uniquely produced based on a properly formatted JSON object, going from abbreviated form to JSON is not supported.
-Therefore, JSON is the preferred storage and transmission method.
-
-### Full JSON format
-
-For a more robust, self-contained, machine-readable, we provide JSON schemas.
 The [provision schema](https://github.com/CERTCC/SSVC/blob/main/data/schema/SSVC_Provision.schema.json) is equivalent to a decision tree and documents the full set of logical statements that a stakeholder uses to make decisions.
 The [computed schema](https://github.com/CERTCC/SSVC/blob/main/data/schema/SSVC_Computed.schema.json) expresses a set of information about a work item or vulnerability at a point in time.
 A computed schema should identify the provision schema used, so the options from which the information was computed are specified.
@@ -90,17 +40,14 @@ A timely partial warning is better than a complete warning that is too late.
 The basic guidance is that the analyst should communicate all of the vulnerability's possible states, to the best of the analyst's knowledge.
 If the analyst knows nothing, all states are possible.
 For example, [*Utility*](#utility) may be [laborious](#utility), [efficient](#utility), or [super effective](#utility).
-In abbreviated form, write this as `U:LESe`.
-Since a capital letter always indicates a new value, this is unambiguous.
 
-The reason a stakeholder might publish something like `U:LESe` is that it expresses that the analyst thought about [*Utility*](#utility) but does not have anything to communicate.
+The reason a stakeholder might publish a decision point with more than one value is that it expresses that the analyst thought about [*Utility*](#utility) but does not have anything to communicate.
 A stakeholder might have information to communicate about some decision points but not others.
 If SSVC uses this format to list the values that are in play for a particular vulnerability, there is no need for a special “I don't know” marker.
 
 The merit in this “list all values” approach emerges when the stakeholder knows that the value for a decision point may be A or B, but not C.
 For example, say the analyst knows that [*Value Density*](#value-density) is [diffuse](#value-density) but does not know the value for [*Automatability*](#automatability).
 Then the analyst can usefully restrict [*Utility*](#utility) to one of [laborious](#utility) or [efficient](#utility).
-In abbreviated form, write this as `U:LE`.
 As discussed below, information can change over time.
 Partial information may be, but is not required to be, sharpened over time into a precise value for the decision point.
 

--- a/docs/howto/communicating_results.md
+++ b/docs/howto/communicating_results.md
@@ -41,7 +41,7 @@ The basic guidance is that the analyst should communicate all of the vulnerabili
 If the analyst knows nothing, all states are possible.
 For example, [*Utility*](#utility) may be [laborious](#utility), [efficient](#utility), or [super effective](#utility).
 
-The reason a stakeholder might publish a decision point with more than one value is that it expresses that the analyst thought about [*Utility*](#utility) but does not have anything to communicate.
+The reason a stakeholder might publish a decision point with all its possible values is that doing so expresses that the analyst thought about [*Utility*](#utility) but does not have anything to communicate.
 A stakeholder might have information to communicate about some decision points but not others.
 If SSVC uses this format to list the values that are in play for a particular vulnerability, there is no need for a special “I don't know” marker.
 

--- a/docs/topics/future_work.md
+++ b/docs/topics/future_work.md
@@ -48,8 +48,7 @@ This study methodology should be repeated with different analyst groups, from di
 
 Internationalization and localization of SSVC will also need to be considered and tested in future work.
 It is not clear how best to consider translating SSVC decision points, if at all.
-And at [a very practical level](https://github.com/CERTCC/SSVC/issues/123), the [Abbreviated Format](#abbreviated-format) would have to define a new algorithm for creating initialisms that is not dependent an an alphabet for languages based on syllabaries or ideograms.
-But a more actionable item of future work would be to include non-native English speakers in future usability studies.
+An actionable item of future work would be to include non-native English speakers in future usability studies.
 
 A different approach to testing the [*Utility*](#utility) decision point could be based on [Alternative Utility Outputs](#alternative-utility-outputs).
 Namely, future work could example exploit resale markets and compare the value of exploits to the [*Utility*](#utility) score of the exploited vulnerability.


### PR DESCRIPTION
This PR removes the "abbreviated format" aka "vector format" from the documentation.

- ran into this while working on #443
- resolves #333 