### PR TITLE
Create link_checker.yml

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,0 +1,41 @@
+name: Link Checker
+on:
+  pull_request:
+    paths:
+      # run on any PR that modifies a markdown file
+      - '**/*.md'
+      # run on any PR that changes this workflow
+      - .github/workflows/linkchecker.yml
+  # let us trigger it manually
+  workflow_dispatch:
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install linkchecker
+
+      - name: Install our python stuff
+        run: |
+          python -m pip install -e src
+
+      - name: Build Site
+        run: |
+          mkdocs build --verbose --clean --config-file mkdocs.yml       
+
+      - name: Check links
+        run: |
+          linkchecker site/index.html
+          


### PR DESCRIPTION
Adds a github workflow that builds the site and checks links anytime a PR wants to change a markdown file.

- resolves #404 

I feel obligated to acknowledge the entirely unintentional fact that issue #404 is the absolute best issue number possible for that specific issue.

This PR is a direct follow-on to 

- #443 

and should be merged immediately after #443 is merged. Rationale: #443 puts the content in a known-good state with no broken links that `linkchecker` can find. So if we add this workflow immediately afterwards, we can ensure that we keep it that way going forward.  Merging this PR _before_ #443 would just leave us with a failing workflow because there are a lot of broken links in the markdown up to that point.