### PR TITLE
Make `link_checker.yml` run automatically on push to `main`

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,5 +1,9 @@
 name: Link Checker
 on:
+  push:
+    branches:
+      # run on any push to main 
+      - main
   pull_request:
     paths:
       # run on any PR that modifies a markdown file


### PR DESCRIPTION
Now that we know it works, we should run linkchecker every time the main branch is updated (this is in addition to running it on all PRs, which is how it was configured after #465)

- extends #465