### PR TITLE
Add topo sort to csv analyzer and policy generator

### DIFF
--- a/data/json/decision_points/report_credibility_1_0_0.json
+++ b/data/json/decision_points/report_credibility_1_0_0.json
@@ -6,14 +6,14 @@
   "description": "Is the report credible?",
   "values": [
     {
-      "key": "C",
-      "name": "Credible",
-      "description": "The report is credible."
-    },
-    {
       "key": "NC",
       "name": "Not Credible",
       "description": "The report is not credible."
+    },
+    {
+      "key": "C",
+      "name": "Credible",
+      "description": "The report is credible."
     }
   ]
 }

--- a/data/json/decision_points/report_public_1_0_0.json
+++ b/data/json/decision_points/report_public_1_0_0.json
@@ -6,14 +6,14 @@
   "description": "Is a viable report of the details of the vulnerability already publicly available?",
   "values": [
     {
-      "key": "N",
-      "name": "No",
-      "description": "No public report of the vulnerability exists."
-    },
-    {
       "key": "Y",
       "name": "Yes",
       "description": "A public report of the vulnerability exists."
+    },
+    {
+      "key": "N",
+      "name": "No",
+      "description": "No public report of the vulnerability exists."
     }
   ]
 }

--- a/docs/_generated/decision_points/report_credibility_1_0_0.md
+++ b/docs/_generated/decision_points/report_credibility_1_0_0.md
@@ -7,8 +7,8 @@
 
         | Value | Definition |
         |:-----|:-----------|
-        | Credible | The report is credible. |
         | Not Credible | The report is not credible. |
+        | Credible | The report is credible. |
         
     === "JSON"
     

--- a/docs/_generated/decision_points/report_public_1_0_0.md
+++ b/docs/_generated/decision_points/report_public_1_0_0.md
@@ -7,8 +7,8 @@
 
         | Value | Definition |
         |:-----|:-----------|
-        | No | No public report of the vulnerability exists. |
         | Yes | A public report of the vulnerability exists. |
+        | No | No public report of the vulnerability exists. |
         
     === "JSON"
     

--- a/src/ssvc/csv_analyzer.py
+++ b/src/ssvc/csv_analyzer.py
@@ -40,7 +40,7 @@ Example:
     Higher values imply more important features.
     """
 
-#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  Copyright (c) 2023-2024 Carnegie Mellon University and Contributors.
 #  - see Contributors.md for a full list of Contributors
 #  - see ContributionInstructions.md for information on how you can Contribute to this project
 #  Stakeholder Specific Vulnerability Categorization (SSVC) is
@@ -54,13 +54,18 @@ Example:
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import argparse
+import logging
 import re
 import sys
+from itertools import product
 
+import networkx as nx
 import pandas as pd
 import sklearn.inspection
 from sklearn.base import clone
 from sklearn.tree import DecisionTreeClassifier
+
+logger = logging.getLogger(__name__)
 
 
 def _col_norm(c: str) -> str:
@@ -203,11 +208,30 @@ def _parse_args(args) -> argparse.Namespace:
 
 
 def main():
+    # set up root logger
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    hdlr = logging.StreamHandler()
+    logger.addHandler(hdlr)
+
     args = _parse_args(sys.argv[1:])
 
     csvfile = args.csvfile
     # read csv
     df = pd.read_csv(csvfile)
+
+    print("Checking for valid topological order...")
+
+    problems = check_topological_order(df, args.outcol)
+
+    if len(problems):
+        print("Not topologically sorted!")
+
+    for problem in problems:
+        print(
+            f"Problem: {problem['u']} ({problem['u_outcome']}) is greater than {problem['v']} ({problem['v_outcome']})"
+        )
+        sys.exit(1)
 
     if args.permutation:
         imp = permute_feature_importance(df, args.outcol)
@@ -219,7 +243,7 @@ def main():
     print(imp)
 
 
-def _create_dt_classifier(
+def _prepare_data(
     df: pd.DataFrame, target: str, permute: bool = False
 ) -> (pd.DataFrame, pd.DataFrame):
     """
@@ -251,10 +275,8 @@ def _create_dt_classifier(
         mapper = {v: k for (k, v) in codes}
         X[newcol] = X[c].replace(mapper)
     X2 = X[cols]
-    # construct tree
-    dt = DecisionTreeClassifier(random_state=99, criterion="entropy")
 
-    return dt, X2, y
+    return X2, y
 
 
 def drop_col_feature_importance(df: pd.DataFrame, target: str) -> pd.DataFrame:
@@ -268,7 +290,10 @@ def drop_col_feature_importance(df: pd.DataFrame, target: str) -> pd.DataFrame:
     Returns:
         a dataframe of feature importances
     """
-    dt, X2, y = _create_dt_classifier(df, target)
+    X2, y = _prepare_data(df, target)
+    # construct tree
+    dt = DecisionTreeClassifier(random_state=99, criterion="entropy")
+
     imp = _drop_col_feat_imp(dt, X2, y)
     return imp
 
@@ -284,9 +309,87 @@ def permute_feature_importance(df: pd.DataFrame, target: str) -> pd.DataFrame:
     Returns:
         a dataframe of feature importances
     """
-    dt, X2, y = _create_dt_classifier(df, target)
+    X2, y = _prepare_data(df, target)
+    # construct tree
+    dt = DecisionTreeClassifier(random_state=99, criterion="entropy")
+
     imp = _perm_feat_imp(dt, X2, y)
     return imp
+
+
+def check_topological_order(df, target):
+    # split df into features and target
+    X, y = _prepare_data(df, target)
+
+    # convert outcome to numeric codes
+    codes = list(enumerate(y.unique()))
+    mapper = {v: k for (k, v) in codes}
+    y = y.replace(mapper)
+
+    # create a graph of the nodes, assign the outcome value to each node
+    # and then check that the graph is topologically sorted
+    # (i.e. no edges point backwards)
+    G = nx.DiGraph()
+    # each row of X is a single node
+    for i, row in enumerate(X.iterrows()):
+        rownum, rowval = row
+
+        # cast the row to a tuple so we can use it as a node
+        node = tuple(rowval)
+        G.add_node(node, outcome=y.iloc[i])
+
+    # add edges
+    for u, v in product(G.nodes, G.nodes):
+        # skip self edges
+        if u == v:
+            continue
+
+        # u is less than v if all elements of u are less than or equal to v
+        if all(u[i] <= v[i] for i in range(len(u))):
+            # and at least one element of u is less than v
+            if any(u[i] < v[i] for i in range(len(u))):
+                # add edge if not already there
+                if not G.has_edge(u, v):
+                    G.add_edge(u, v)
+
+        # v is less than u if all elements of v are less than or equal to u
+        if all(v[i] <= u[i] for i in range(len(v))):
+            # and at least one element of v is less than u
+            if any(v[i] < u[i] for i in range(len(v))):
+                # add edge if not already there
+                if not G.has_edge(v, u):
+                    G.add_edge(v, u)
+
+    # take the transitive reduction of G to remove redundant edges
+    # this will remove all edges that are implied by other edges
+    # and leave only the minimal set of edges
+    # H is thus a Hasse diagram of G
+    H = nx.transitive_reduction(G)
+
+    # networkx transitive reduction doesn't copy the node data
+    # so we need to copy it from G to H
+    for u in H.nodes:
+        H.nodes[u]["outcome"] = G.nodes[u]["outcome"]
+
+    logger.debug(f"Original graph: {len(G.nodes)} nodes with {len(G.edges)} edges")
+    logger.debug(f"Reduced graph: {len(H.nodes)} nodes with {len(H.edges)} edges")
+
+    problems = []
+    # check if the outcome is topologically sorted
+    for u, v in H.edges:
+        if H.nodes[u]["outcome"] > H.nodes[v]["outcome"]:
+            problem = {
+                "u": u,
+                "v": v,
+                "u_outcome": H.nodes[u]["outcome"],
+                "v_outcome": H.nodes[v]["outcome"],
+            }
+            problems.append(problem)
+
+    if len(problems) == 0:
+        logger.info("No topological problems found")
+
+    return problems
 
 
 if __name__ == "__main__":

--- a/src/ssvc/decision_points/report_credibility.py
+++ b/src/ssvc/decision_points/report_credibility.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python
 """
-file: report_credibility
-author: adh
-created_at: 9/21/23 11:24 AM
+Provides the SSVC Report Credibility Decision Point
 """
+
+#  Copyright (c) 2023-2024 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from ssvc.decision_points.base import SsvcDecisionPoint, SsvcDecisionPointValue
 
@@ -25,8 +36,8 @@ REPORT_CREDIBILITY_1 = SsvcDecisionPoint(
     key="RC",
     version="1.0.0",
     values=(
-        CREDIBLE,
         NOT_CREDIBLE,
+        CREDIBLE,
     ),
 )
 

--- a/src/ssvc/decision_points/report_public.py
+++ b/src/ssvc/decision_points/report_public.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python
 """
-file: report_public
-author: adh
-created_at: 9/21/23 11:15 AM
+Provides the SSVC Report Public Decision Point
 """
+#  Copyright (c) 2023-2024 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
 from ssvc.decision_points.base import SsvcDecisionPoint, SsvcDecisionPointValue
 
 YES = SsvcDecisionPointValue(
@@ -24,8 +35,8 @@ REPORT_PUBLIC_1 = SsvcDecisionPoint(
     key="RP",
     version="1.0.0",
     values=(
-        NO,
         YES,
+        NO,
     ),
 )
 

--- a/src/test/test_csv_analyzer.py
+++ b/src/test/test_csv_analyzer.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  Copyright (c) 2023-2024 Carnegie Mellon University and Contributors.
 #  - see Contributors.md for a full list of Contributors
 #  - see ContributionInstructions.md for information on how you can Contribute to this project
 #  Stakeholder Specific Vulnerability Categorization (SSVC) is
@@ -149,21 +149,20 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(args.outcol, "priority")
         self.assertFalse(args.permutation)
 
-    def test_create_dt_classifier(self):
+    def test_prepare_data(self):
         df = pd.DataFrame()
         target = "outcome"
 
         # key error when target is not in df.columns
         self.assertNotIn(target, df.columns)
-        self.assertRaises(KeyError, acsv._create_dt_classifier, df, target)
+        self.assertRaises(KeyError, acsv._prepare_data, df, target)
 
         df["color"] = [1, 1, 1, 1, 2, 2, 2, 2]
         df["size"] = [1, 2, 3, 4, 1, 2, 3, 4]
         df["outcome"] = [1, 1, 1, 1, 2, 2, 2, 2]
 
         # create_dt_classifier should return a DecisionTreeClassifier object
-        model, x, y = acsv._create_dt_classifier(df, target)
-        self.assertIsInstance(model, acsv.DecisionTreeClassifier)
+        x, y = acsv._prepare_data(df, target)
         self.assertIsInstance(x, pd.DataFrame)
         self.assertIsInstance(y, pd.Series)
 

--- a/src/test/test_policy_generator.py
+++ b/src/test/test_policy_generator.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 Carnegie Mellon University and Contributors.
+#  Copyright (c) 2023-2024 Carnegie Mellon University and Contributors.
 #  - see Contributors.md for a full list of Contributors
 #  - see ContributionInstructions.md for information on how you can Contribute to this project
 #  Stakeholder Specific Vulnerability Categorization (SSVC) is
@@ -285,6 +285,40 @@ class MyTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pg._validate_paths()
+
+    def test_is_topological_order(self):
+        pg = PolicyGenerator(
+            dp_group=self.dpg,
+            outcomes=self.og,
+        )
+        # just replace the graph with one we make up here
+        # 0 - 1 - 2 - 4 - 5
+        #      \- 3 -/
+
+        pg.G = nx.DiGraph()
+        pg.G.add_edges_from([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)])
+
+        self.assertTrue(pg._is_topological_order([0, 1, 2, 3, 4, 5]))
+        self.assertTrue(pg._is_topological_order([0, 1, 3, 2, 4, 5]))
+        self.assertFalse(pg._is_topological_order([0, 1, 2, 4, 3, 5]))
+        self.assertFalse(pg._is_topological_order([0, 1, 2, 3, 5]))
+
+    def test_confirm_topological_order(self):
+        pg = PolicyGenerator(
+            dp_group=self.dpg,
+            outcomes=self.og,
+        )
+        # just replace the graph with one we make up here
+        # 0 - 1 - 2 - 4 - 5
+        #      \- 3 -/
+
+        pg.G = nx.DiGraph()
+        pg.G.add_edges_from([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)])
+
+        self.assertIsNone(pg._confirm_topological_order([0, 1, 2, 3, 4, 5]))
+        self.assertIsNone(pg._confirm_topological_order([0, 1, 3, 2, 4, 5]))
+        self.assertRaises(ValueError, pg._confirm_topological_order, [0, 1, 2, 4, 3, 5])
+        self.assertRaises(ValueError, pg._confirm_topological_order, [0, 1, 2, 3, 5])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR 
- adds some topological sort checks to the csv analyzer and policy generator scripts.
- reorders the `report public` and `report credibility` decision points to match expected directionality of values

These features were added after I noticed that report public and report credibility were improperly ordered according to the policy generator assumption that decision points are ordered from lowest-to-highest along a dimension that correlates to "likely to act". 