### PR TITLE
Expand SSVC acronym in site name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: SSVC
+site_name: "SSVC: Stakeholder-Specific Vulnerability Categorization"
 copyright: Copyright &copy; 2024 Carnegie Mellon University.
 nav:
   - Home: 'index.md'


### PR DESCRIPTION
This PR is a one-liner that changes the title string in the site header from "SSVC" to "SSVC: Stakeholder-Specific Vulnerability Categorization"