### PR TITLE
Reorder howto section navigation

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -48,10 +48,10 @@ fit your organization's needs.
 
 <div class="grid cards" markdown>
 
+- :material-stairs: [Bootstrapping SSVC](bootstrap/index.md)
 - :material-factory: [Supplier Decision Model](supplier_tree.md)
 - :material-server-network: [Deployer Decision Model](deployer_tree.md)
 - :material-steering: [Coordinator Decision Models](coordination_intro.md)
-- :material-stairs: [Bootstrapping SSVC](bootstrap/index.md)
 - :material-hand-saw: [Customizing SSVC](tree_customization.md)
 - :material-slope-uphill: [Acuity Ramp](acuity_ramp.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,13 @@ nav:
     - Limitations: 'topics/limitations.md'
     - Future Work: 'topics/future_work.md'
   - SSVC How-To:
-    - Intro: 'howto/index.md'
+    - Overview: 'howto/index.md'
+    - Bootstrapping SSVC:
+      - Intro: 'howto/bootstrap/index.md'
+      - Prepare: 'howto/bootstrap/prepare.md'
+      - Collect: 'howto/bootstrap/collect.md'
+      - Use & Respond: 'howto/bootstrap/use.md'
+      - Summary: 'howto/bootstrap/summary.md'
     - Stakeholder Decision Models:
         - Supplier Decision Model: 'howto/supplier_tree.md'
         - Deployer Decision Model: 'howto/deployer_tree.md'
@@ -38,12 +44,6 @@ nav:
           - About Coordination: 'howto/coordination_intro.md'
           - Coordination Decision: 'howto/coordination_decisions.md'
           - Publication Decision: 'howto/publication_decision.md'
-    - Bootstrapping SSVC:
-      - Intro: 'howto/bootstrap/index.md'
-      - Prepare: 'howto/bootstrap/prepare.md'
-      - Collect: 'howto/bootstrap/collect.md'
-      - Use & Respond: 'howto/bootstrap/use.md'
-      - Summary: 'howto/bootstrap/summary.md'
     - Customizing SSVC: 'howto/tree_customization.md'
     - Acuity Ramp: 'howto/acuity_ramp.md'
   - Reference:


### PR DESCRIPTION
- resolves #481 

This PR moves the Bootstrapping SSVC content to the beginning of the HowTo section

Also renames the HowTo `Intro` to `Overview` to avoid having `Intro` appear twice in a row