### PR TITLE
Add Calculator blurb to `Learning SSVC`

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,6 +2,12 @@
 
 {== todo add intro ==}
 
+!!! tip "SSVC Calculator"
+
+    We've created a simple [SSVC Calculator](../ssvc-calc/index.md) to help you understand how SSVC decision models work.
+    The decisions modeled in the calculator are based on the [Supplier](../howto/supplier_tree.md),
+    [Deployer](../howto/deployer_tree.md), and [Coordinator](../howto/coordination_intro.md) decision models.
+
 ## Videos
 
 | Source | Video                                                                                                                            |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,7 @@ site_name: "SSVC: Stakeholder-Specific Vulnerability Categorization"
 copyright: Copyright &copy; 2024 Carnegie Mellon University.
 nav:
   - Home: 'index.md'
-  - Learning SSVC:
-    - Intro: 'tutorials/index.md'
-    - SSVC Calculator: 'ssvc-calc/index.md'
+  - Learning SSVC: 'tutorials/index.md'
   - SSVC How-To:
     - Overview: 'howto/index.md'
     - Getting Started with SSVC:


### PR DESCRIPTION
This PR adds a small blurb for the calculator on the Learning home page. See screenshot.

<img width="400" alt="Screenshot 2024-02-29 at 2 44 40 PM" src="https://github.com/CERTCC/SSVC/assets/2594236/92501569-6725-4b45-9243-b0c08f246706">
