### PR TITLE
Add js to fix latex rendering on page load

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -12,5 +12,8 @@ window.MathJax = {
 };
 
 document$.subscribe(() => {
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
   MathJax.typesetPromise()
 })


### PR DESCRIPTION
This PR alters how `mathjax.js` renders $\LaTeX$ in pages. This fixes a minor annoyance that pages sometimes fail to render math correctly on the first load, but look fine on reload. The change here eliminates the need to reload the page.

Copied from CERTCC/Vultron#74