### PR TITLE
Set up site deployment on publish branch

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -5,9 +5,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting specific branch(es)
   push:
-    branches: [main, staging]
+    branches:
+      - publish
 
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
This PR changes `.github/workflows/deploy_site.yml` so that it will run on pushes to the `publish` branch. This is needed so that we can deploy the new site to `certcc.github.io/SSVC`