### PR TITLE
Configure sitemap.xml to be populated

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: "SSVC: Stakeholder-Specific Vulnerability Categorization"
+site_url: 'https://certcc.github.io/SSVC/'
+site_description: 'SSVC is a framework for prioritizing vulnerabilities based on stakeholder needs.'
+site_author: 'CERT Coordination Center'
 copyright: >
   Copyright &copy; 2019-2024 Carnegie Mellon University.
   <br/><a href="#__consent">Change cookie settings</a>


### PR DESCRIPTION
This PR activates the mkdocs features that will cause the sitemap.xml file to be populated.

https://certcc.github.io/SSVC/sitemap.xml

see for contrast

https://certcc.github.io/Vultron/sitemap.xml

Why sitemap.xml is important: https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview