### PR TITLE
Updated Mission-Impact in Deployer.json and in csvs/child_trees to ma…

### DIFF
--- a/data/csvs/child_trees/human-impact.csv
+++ b/data/csvs/child_trees/human-impact.csv
@@ -1,25 +1,20 @@
  Situated Safety Impact , Mission Impact , Human Impact 
- None , None , Low 
  None , Degraded , Low 
  None , Crippled , Low 
  None , MEF Failure , Medium 
  None , Mission Failure , Very High 
- Minor , None , Low 
  Minor , Degraded , Low 
  Minor , Crippled , Low 
  Minor , MEF Failure , Medium 
  Minor , Mission Failure , Very High 
- Major , None , Medium 
  Major , Degraded , Medium 
  Major , Crippled , Medium 
  Major , MEF Failure , High 
  Major , Mission Failure , Very High 
- Hazardous , None , High 
  Hazardous , Degraded , High 
  Hazardous , Crippled , High 
  Hazardous , MEF Failure , High 
  Hazardous , Mission Failure , Very High 
- Catastrophic , None , Very High
  Catastrophic , Degraded , Very High
  Catastrophic , Crippled , Very High
  Catastrophic , MEF Failure , Very High 

--- a/docs/ssvc-calc/Deployer.json
+++ b/docs/ssvc-calc/Deployer.json
@@ -100,11 +100,6 @@
             "key": "M",
             "options": [
                 {
-                    "label": "none",
-                    "key": "N",
-                    "description": "Little to no impact up to degradation of non-essential functions; chronic degradation would eventually harm essential functions. (aka Non-Essential Degraded)"
-                },
-                {
                     "label": "degraded",
                     "key": "D",
                     "description": "Little to no impact up to degradation of non-essential functions; chronic degradation would eventually harm essential functions. (aka Non-Essential Degraded)"
@@ -158,7 +153,6 @@
 			      "child_label": "Mission Impact",
 			      "child_key": "M",
 			      "child_option_labels":[
-				  "none",
 				  "degraded",
 				  "crippled"
 			      ]
@@ -201,7 +195,6 @@
 			      "child_label": "Mission Impact",
 			      "child_key": "M",
 			      "child_option_labels":[
-				  "none",
 				  "degraded",
 				  "crippled"
 			      ]
@@ -243,7 +236,6 @@
 			      "child_label": "Mission Impact",
 			      "child_key": "M",
 			      "child_option_labels":[
-				  "none",
 				  "degraded",
 				  "crippled",
 				  "mef failure"
@@ -292,7 +284,6 @@
 			      "child_label": "Mission Impact",
 			      "child_key": "M",
 			      "child_option_labels":[
-				  "none",
 				  "degraded",
 				  "crippled",
 				  "mef failure",
@@ -844,6 +835,6 @@
       }	
     ],
     "lang": "en",
-    "version": "2.0",
+    "version": "2.0.0",
     "title": "Deployer v2.1.0"
 }


### PR DESCRIPTION
As identified in Issue #558 and in #513  - the Mission Impact has the legacy option None still lingering. Cleaning this up for proper representation.

