### PR TITLE
Replace vuls.cert.org CVD guide links with certcc.github.io links

### DIFF
--- a/docs/howto/coordination_intro.md
+++ b/docs/howto/coordination_intro.md
@@ -11,7 +11,7 @@ A coordinator may want to gather and publish information about SSVC decision poi
 Furthermore, a coordinator may only publish some of the information it uses to make decisions.
 Consistent with other stakeholder perspectives (supplier and deployer), SSVC provides the priority with which a coordinator should take some defined action, but not how to do that action.
 For more information about types of coordinators and their facilitation actions within vulnerability management, see
-[The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/3.5.+Coordinator)
+[The CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/topics/roles/coordinator/)
 
 The two decisions that CERT/CC makes as a coordinator that we will discuss in terms of SSVC are 
 
@@ -27,7 +27,7 @@ These two decisions are not the entirety of vulnerability coordination, but we l
 
 
 Different coordinators have different scopes and constituencies.
-See [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/3.5.+Coordinator) for a listing of different coordinator types.
+See [The CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/topics/roles/coordinator/) for a listing of different coordinator types.
 If a coordinator receives a report that is outside its own work scope or constituency, it should make an effort to route the report to a more suitable coordinator.
 The decisions in this section assume the report or vulnerability in question is within the work scope or constituency for the coordinator.
 

--- a/docs/howto/coordination_triage_decision.md
+++ b/docs/howto/coordination_triage_decision.md
@@ -27,7 +27,7 @@ SSVC can be applied to either the initial report or to the results of such refin
 
 ## Coordinator Triage Decision Outcomes
 
-We take three priority levels in our decision about whether and how to [coordinate](https://vuls.cert.org/confluence/display/CVD/1.1.+Coordinated+Vulnerability+Disclosure+is+a+Process%2C+Not+an+Event)
+We take three priority levels in our decision about whether and how to [coordinate](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/cvd_is_a_process/)
 a vulnerability based on an incoming report:
 
 !!! info "Coordinator Triage Priority"
@@ -57,7 +57,7 @@ a vulnerability based on an incoming report:
     (VRDA) provides a starting point for a decision model for this situation.
     VRDA is likely [adequate](https://insights.sei.cmu.edu/library/effectiveness-of-the-vulnerability-response-decision-assistance-vrda-framework/)
     for national-level CSIRTs that do general CVD, but other CSIRT types may have different needs.
-    The [*CERT Guide to Coordinated Vulnerability Disclosure*](https://vuls.cert.org/confluence/display/CVD/6.10+Troubleshooting+Coordinated+Vulnerability+Disclosure+Table)
+    The [*CERT Guide to Coordinated Vulnerability Disclosure*](https://certcc.github.io/CERT-Guide-to-CVD/howto/coordination/cvd_recipes/)
     provides something similar for those who are deciding how to report and disclose vulnerabilities they have discovered.
 
 The coordination and publication decisions for CERT/CC are about the social and collaborative state of vulnerability management.

--- a/docs/howto/publication_decision.md
+++ b/docs/howto/publication_decision.md
@@ -31,7 +31,7 @@ Two points where CERT/CC policy clearly influences the publication decision are 
 As a matter of policy, CERT/CC will support an embargo from the public of information about a vulnerability through its
 choice not to publish that information while a number of conditions hold:
    
-  - A negotiated embargo timer has not expired. The CERT/CC default embargo period is [45 days](https://vuls.cert.org/confluence/display/Wiki/Vulnerability+Disclosure+Policy).
+  - A negotiated embargo timer has not expired. The CERT/CC default embargo period is [45 days](https://certcc.github.io/CERT-Guide-to-CVD/reference/certcc_disclosure_policy/).
   - Other exceptions have not been met, including active exploitation of the vulnerability in the wild or other public
     discussion of the vulnerability details.
 


### PR DESCRIPTION
We just launched the latest CVD guide at https://certcc.github.io/CERT-Guide-to-CVD/

This PR changes the links from the Confluence version of the Guide to the new github.io version.

- resolves #561

