### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,7 +187,6 @@ extra:
 extra_javascript:
   # to render math
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   # to sort tables
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js


### PR DESCRIPTION
Remove link to polyfill.io 
See https://github.com/squidfunk/mkdocs-material/issues/7295
and https://censys.com/july-2-polyfill-io-supply-chain-attack-digging-into-the-web-of-compromised-domains/