### PR TITLE
Fix bad import in PolicyGenerator

### DIFF
--- a/src/ssvc/policy_generator.py
+++ b/src/ssvc/policy_generator.py
@@ -328,7 +328,7 @@ class PolicyGenerator:
 
 
 def main():
-    from ssvc.decision_points.automatable import AUTOMATABLE_1
+    from ssvc.decision_points.automatable import AUTOMATABLE_2
     from ssvc.decision_points.exploitation import EXPLOITATION_1
     from ssvc.decision_points.human_impact import HUMAN_IMPACT_2
     from ssvc.decision_points.system_exposure import SYSTEM_EXPOSURE_1_0_1
@@ -347,7 +347,7 @@ def main():
         decision_points=[
             EXPLOITATION_1,
             SYSTEM_EXPOSURE_1_0_1,
-            AUTOMATABLE_1,
+            AUTOMATABLE_2,
             HUMAN_IMPACT_2,
         ],
     )


### PR DESCRIPTION
- fixes #590 

`AUTOMATABLE_1` went away at some point (becoming `VIRULENCE_1`) and so we need to use `AUTOMATABLE_2` instead in the example code.