### PR TITLE
schema URL's ID field is garbled

### DIFF
--- a/data/schema/v1/Decision_Point-1-0-1.schema.json
+++ b/data/schema/v1/Decision_Point-1-0-1.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Decision Point schema definition",
-    "$id": "https://certcc.github.io/data/schema/v1/Decision_Point.schema-1-0-1.json",
+    "$id": "https://certcc.github.io/SSVC/data/schema/v1/Decision_Point-1-0-1.schema.json",
     "description": "Decision points are the basic building blocks of SSVC decision functions. Individual decision points describe a single aspect of the input to a decision function.",
     "definitions":     {
 	"schemaVersion": {

--- a/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json
+++ b/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://certcc.github.io/SSVC/data/schema/v1/Decision_Point_Group_Selection-1-0-1.schema.json",
+    "$id": "https://certcc.github.io/SSVC/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json",
     "definitions": {
 	"id": {
             "type": "string",


### PR DESCRIPTION
Looks like the id field on two of the schema files are garbled. These should be correct now.

