### PR TITLE
Change json schema base to 2020-12

### DIFF
--- a/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json
+++ b/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://certcc.github.io/SSVC/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json",
     "definitions": {
 	"id": {


### PR DESCRIPTION
This PR modifies the base url for the JSON schema to change from `draft-07` to `2020-12`

- https://json-schema.org/draft/2020-12/release-notes

Original text:

> This will be a good one to merge to Main and then finally publish with all the latest changes. I don't think any version  number changes are needed as the schema is entirely the same and works fine with both draft-07 and 2020-12 the same way.
> Vijay