### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,12 @@
+- Remove this template and add a description of the changes you are proposing.
+- Most pull requests should be in response to an issue, and ideally a PR will
+resolve or close one or more issues. 
+- If a PR only partially resolves an issue,
+we suggest spawning one or more child issues from the main issue to identify what portion
+of the issue is resolved by the PR, and what work remains to be done.
+- Please use github keywords (closes, fixes, resolves, etc.) to reference relevant issues.
+- Using bulleted lists with the issue id at the end lets github automatically
+link the issue and provide the title inline.
+- CoPilot summaries are welcome in the PR description, but please provide a brief
+description of the changes in your own words as well. CoPilot can be good at the _what_,
+but not so good at the _why_.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,12 +1,17 @@
 - Remove this template and add a description of the changes you are proposing.
+- Edit the title of the PR to be a concise summary of the changes. The title should
+  be descriptive enough to give a reviewer a good idea of what the PR is about, and
+  not just a reference to an issue number. PR titles are used in the commit log
+  and release notes, so they need to convey meaning on their own.
 - Most pull requests should be in response to an issue, and ideally a PR will
-resolve or close one or more issues. 
+  resolve or close one or more issues. 
 - If a PR only partially resolves an issue,
-we suggest spawning one or more child issues from the main issue to identify what portion
-of the issue is resolved by the PR, and what work remains to be done.
-- Please use github keywords (closes, fixes, resolves, etc.) to reference relevant issues.
+  we suggest spawning one or more child issues from the main issue to identify what portion
+  of the issue is resolved by the PR, and what work remains to be done.
+- Please use [github keyword syntax](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
+  (closes, fixes, resolves, etc.) to reference relevant issues.
 - Using bulleted lists with the issue id at the end lets github automatically
-link the issue and provide the title inline.
+  link the issue and provide the title inline. E.g.: `- resolves #99999`
 - CoPilot summaries are welcome in the PR description, but please provide a brief
 description of the changes in your own words as well. CoPilot can be good at the _what_,
 but not so good at the _why_.


### PR DESCRIPTION
This pull request adds a pull request template to provide clearer guidelines on describing the proposed changes, referencing relevant issues, and using GitHub keywords for issue linking.

Changes to pull request template:

* [`.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`](diffhunk://#diff-45659dae3c8acfb7058b31c52c8600ca9c72a11a482372feea9ab85cb0f270faR1-R12): Updated the template to include instructions on removing the template text, resolving or closing issues, using GitHub keywords, and providing a brief description of changes in addition to CoPilot summaries.