### PR TITLE
Add semantic versioning validator to _Versioned mixin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scikit-learn==1.6.1
 jsonschema==4.23.0
 networkx==3.4.2
 pydantic==2.10.6
+semver==3.0.2

--- a/src/ssvc/_mixins.py
+++ b/src/ssvc/_mixins.py
@@ -17,7 +17,8 @@ This module provides mixin classes for adding features to SSVC objects.
 
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+from semver import Version
 
 from . import _schemaVersion
 
@@ -29,6 +30,23 @@ class _Versioned(BaseModel):
 
     version: str = "0.0.0"
     schemaVersion: str = _schemaVersion
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, value):
+        """
+        Validate the version field.
+        Args:
+            value: a string representing a version number
+
+        Returns:
+            a fully qualified version number
+
+        Raises:
+            ValueError: if the value is not a valid version number
+        """
+        version = Version.parse(value, optional_minor_and_patch=True)
+        return version.__str__()
 
 
 class _Namespaced(BaseModel):


### PR DESCRIPTION
- resolves #347 

This PR takes advantage of our switch to pydantic data classes in #674 to add a field validator on the `_Versioned` mixin class that enforces valid semver strings in the`version` attribute.

## Copilot summary

This pull request includes updates to the `src/ssvc/_mixins.py` file to improve version validation by adding a new dependency and a validation method.

Validation improvements:

* [`src/ssvc/_mixins.py`](diffhunk://#diff-3e266c8592982d40cd5b33b96e21eaa4399524f834f5d2a239c0a5e0e65fc788L20-R21): Added `semver` library import to handle version parsing and validation.
* [`src/ssvc/_mixins.py`](diffhunk://#diff-3e266c8592982d40cd5b33b96e21eaa4399524f834f5d2a239c0a5e0e65fc788R34-R50): Introduced a `validate_version` method in the `_Versioned` class using `field_validator` to ensure the `version` field is a valid version number. This method parses the version string and raises a `ValueError` if it is not valid.