### PR TITLE
Update json examples in repository

### DIFF
--- a/data/json/decision_points/cvss/automatable_1_0_0.json
+++ b/data/json/decision_points/cvss/automatable_1_0_0.json
@@ -15,6 +15,11 @@
       "key": "Y",
       "name": "Yes",
       "description": "Attackers can reliably automate all 4 steps of the kill chain. These steps are reconnaissance, weaponization, delivery, and exploitation (e.g., the vulnerability is \"wormable\")."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
     }
   ]
 }

--- a/data/json/decision_points/cvss/availability_impact_to_the_subsequent_system_1_0_0.json
+++ b/data/json/decision_points/cvss/availability_impact_to_the_subsequent_system_1_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "1.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "SA",
+  "name": "Availability Impact to the Subsequent System",
+  "description": "This metric measures the impact on availability a successful exploit of the vulnerability will have on the Subsequent System.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no impact to availability within the Subsequent System or all availability impact is constrained to the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Performance is reduced or there are interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of availability, resulting in the attacker being able to fully deny access to resources in the Subsequent System; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/availability_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/availability_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "VA",
+  "name": "Availability Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the availability of the impacted system resulting from a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no impact to availability within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is reduced performance or interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users. The resources in the Vulnerable System are either partially available all of the time, or fully available only some of the time, but overall there is no direct, serious consequence to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of availability, resulting in the attacker being able to fully deny access to resources in the impacted component; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/confidentiality_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/confidentiality_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "VC",
+  "name": "Confidentiality Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the confidentiality of the information managed by the system due to a successfully exploited vulnerability. Confidentiality refers to limiting information access and disclosure to only authorized users, as well as preventing access by, or disclosure to, unauthorized ones.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of confidentiality within the impacted component."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is constrained. The information disclosure does not cause a direct, serious loss to the impacted component."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator's password, or private encryption keys of a web server."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/integrity_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/integrity_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "VI",
+  "name": "Integrity Impact to the Vulnerable System",
+  "description": "This metric measures the impact to integrity of a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of integrity within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is limited. The data modification does not have a direct, serious impact to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of integrity, or a complete loss of protection."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/integrity_requirement_1_1_1.json
+++ b/data/json/decision_points/cvss/integrity_requirement_1_1_1.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "1.1.1",
+  "schemaVersion": "1-0-1",
+  "key": "IR",
+  "name": "Integrity Requirement",
+  "description": "This metric enables the consumer to customize the assessment depending on the importance of the affected IT asset to the analyst’s organization, measured in terms of Confidentiality.",
+  "values": [
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Loss of integrity is likely to have only a limited adverse effect on the organization or individuals associated with the organization (e.g., employees, customers)."
+    },
+    {
+      "key": "M",
+      "name": "Medium",
+      "description": "Loss of integrity is likely to have a serious adverse effect on the organization or individuals associated with the organization (e.g., employees, customers)."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "Loss of integrity is likely to have a catastrophic adverse effect on the organization or individuals associated with the organization (e.g., employees, customers)."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_availability_impact_to_the_subsequent_system_1_0_0.json
+++ b/data/json/decision_points/cvss/modified_availability_impact_to_the_subsequent_system_1_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "1.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MSA",
+  "name": "Modified Availability Impact to the Subsequent System",
+  "description": "This metric measures the impact on availability a successful exploit of the vulnerability will have on the Subsequent System.",
+  "values": [
+    {
+      "key": "N",
+      "name": "Negligible",
+      "description": "There is no impact to availability within the Subsequent System or all availability impact is constrained to the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Performance is reduced or there are interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of availability, resulting in the attacker being able to fully deny access to resources in the Subsequent System; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_availability_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/modified_availability_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MVA",
+  "name": "Modified Availability Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the availability of the impacted system resulting from a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no impact to availability within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is reduced performance or interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users. The resources in the Vulnerable System are either partially available all of the time, or fully available only some of the time, but overall there is no direct, serious consequence to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of availability, resulting in the attacker being able to fully deny access to resources in the impacted component; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_confidentiality_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/modified_confidentiality_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MVC",
+  "name": "Modified Confidentiality Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the confidentiality of the information managed by the system due to a successfully exploited vulnerability. Confidentiality refers to limiting information access and disclosure to only authorized users, as well as preventing access by, or disclosure to, unauthorized ones.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of confidentiality within the impacted component."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is constrained. The information disclosure does not cause a direct, serious loss to the impacted component."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator's password, or private encryption keys of a web server."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_integrity_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/modified_integrity_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MVI",
+  "name": "Modified Integrity Impact to the Vulnerable System",
+  "description": "This metric measures the impact to integrity of a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of integrity within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is limited. The data modification does not have a direct, serious impact to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of integrity, or a complete loss of protection."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}


### PR DESCRIPTION
Forgot to run doctools.py after we modified some of the decision points. This only affects the examples in the `/data/json/decision_points` dir in the repository, the site now generates the reference examples on the fly because of #683 