### PR TITLE
Catch up publish to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -7,6 +7,6 @@ assignees: ''
 
 ---
 
-_Note:_ Questions for the SSVC team can be asked here in the form of an issue. More general questions directed at the SSVC user community
+*Note:* Questions for the SSVC team can be asked here in the form of an issue. More general questions directed at the SSVC user community
 might be a better fit in the [Q&A](https://github.com/CERTCC/SSVC/discussions/categories/q-a) category of our
 [Discussions](https://github.com/CERTCC/SSVC/discussions) area.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -4,7 +4,7 @@
   not just a reference to an issue number. PR titles are used in the commit log
   and release notes, so they need to convey meaning on their own.
 - Most pull requests should be in response to an issue, and ideally a PR will
-  resolve or close one or more issues. 
+  resolve or close one or more issues.
 - If a PR only partially resolves an issue,
   we suggest spawning one or more child issues from the main issue to identify what portion
   of the issue is resolved by the PR, and what work remains to be done.
@@ -13,5 +13,5 @@
 - Using bulleted lists with the issue id at the end lets github automatically
   link the issue and provide the title inline. E.g.: `- resolves #99999`
 - CoPilot summaries are welcome in the PR description, but please provide a brief
-description of the changes in your own words as well. CoPilot can be good at the _what_,
-but not so good at the _why_.
+description of the changes in your own words as well. CoPilot can be good at the *what*,
+but not so good at the *why*.

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Build Site
         run: |
+          export PYTHONPATH=./src;$PYTHONPATH
           mkdocs build --verbose --clean --config-file mkdocs.yml       
 
       - name: Upload artifact

--- a/data/json/decision_points/cvss/automatable_1_0_0.json
+++ b/data/json/decision_points/cvss/automatable_1_0_0.json
@@ -15,6 +15,11 @@
       "key": "Y",
       "name": "Yes",
       "description": "Attackers can reliably automate all 4 steps of the kill chain. These steps are reconnaissance, weaponization, delivery, and exploitation (e.g., the vulnerability is \"wormable\")."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
     }
   ]
 }

--- a/data/json/decision_points/cvss/availability_impact_to_the_subsequent_system_1_0_0.json
+++ b/data/json/decision_points/cvss/availability_impact_to_the_subsequent_system_1_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "1.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "SA",
+  "name": "Availability Impact to the Subsequent System",
+  "description": "This metric measures the impact on availability a successful exploit of the vulnerability will have on the Subsequent System.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no impact to availability within the Subsequent System or all availability impact is constrained to the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Performance is reduced or there are interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of availability, resulting in the attacker being able to fully deny access to resources in the Subsequent System; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/availability_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/availability_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "VA",
+  "name": "Availability Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the availability of the impacted system resulting from a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no impact to availability within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is reduced performance or interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users. The resources in the Vulnerable System are either partially available all of the time, or fully available only some of the time, but overall there is no direct, serious consequence to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of availability, resulting in the attacker being able to fully deny access to resources in the impacted component; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/confidentiality_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/confidentiality_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "VC",
+  "name": "Confidentiality Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the confidentiality of the information managed by the system due to a successfully exploited vulnerability. Confidentiality refers to limiting information access and disclosure to only authorized users, as well as preventing access by, or disclosure to, unauthorized ones.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of confidentiality within the impacted component."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is constrained. The information disclosure does not cause a direct, serious loss to the impacted component."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator's password, or private encryption keys of a web server."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/integrity_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/integrity_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "VI",
+  "name": "Integrity Impact to the Vulnerable System",
+  "description": "This metric measures the impact to integrity of a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of integrity within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is limited. The data modification does not have a direct, serious impact to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of integrity, or a complete loss of protection."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/integrity_requirement_1_1_1.json
+++ b/data/json/decision_points/cvss/integrity_requirement_1_1_1.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "1.1.1",
+  "schemaVersion": "1-0-1",
+  "key": "IR",
+  "name": "Integrity Requirement",
+  "description": "This metric enables the consumer to customize the assessment depending on the importance of the affected IT asset to the analyst’s organization, measured in terms of Confidentiality.",
+  "values": [
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Loss of integrity is likely to have only a limited adverse effect on the organization or individuals associated with the organization (e.g., employees, customers)."
+    },
+    {
+      "key": "M",
+      "name": "Medium",
+      "description": "Loss of integrity is likely to have a serious adverse effect on the organization or individuals associated with the organization (e.g., employees, customers)."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "Loss of integrity is likely to have a catastrophic adverse effect on the organization or individuals associated with the organization (e.g., employees, customers)."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_availability_impact_to_the_subsequent_system_1_0_0.json
+++ b/data/json/decision_points/cvss/modified_availability_impact_to_the_subsequent_system_1_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "1.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MSA",
+  "name": "Modified Availability Impact to the Subsequent System",
+  "description": "This metric measures the impact on availability a successful exploit of the vulnerability will have on the Subsequent System.",
+  "values": [
+    {
+      "key": "N",
+      "name": "Negligible",
+      "description": "There is no impact to availability within the Subsequent System or all availability impact is constrained to the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Performance is reduced or there are interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of availability, resulting in the attacker being able to fully deny access to resources in the Subsequent System; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_availability_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/modified_availability_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MVA",
+  "name": "Modified Availability Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the availability of the impacted system resulting from a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no impact to availability within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is reduced performance or interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users. The resources in the Vulnerable System are either partially available all of the time, or fully available only some of the time, but overall there is no direct, serious consequence to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of availability, resulting in the attacker being able to fully deny access to resources in the impacted component; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed)."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_confidentiality_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/modified_confidentiality_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MVC",
+  "name": "Modified Confidentiality Impact to the Vulnerable System",
+  "description": "This metric measures the impact to the confidentiality of the information managed by the system due to a successfully exploited vulnerability. Confidentiality refers to limiting information access and disclosure to only authorized users, as well as preventing access by, or disclosure to, unauthorized ones.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of confidentiality within the impacted component."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is constrained. The information disclosure does not cause a direct, serious loss to the impacted component."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator's password, or private encryption keys of a web server."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/data/json/decision_points/cvss/modified_integrity_impact_to_the_vulnerable_system_3_0_0.json
+++ b/data/json/decision_points/cvss/modified_integrity_impact_to_the_vulnerable_system_3_0_0.json
@@ -1,0 +1,30 @@
+{
+  "namespace": "cvss",
+  "version": "3.0.0",
+  "schemaVersion": "1-0-1",
+  "key": "MVI",
+  "name": "Modified Integrity Impact to the Vulnerable System",
+  "description": "This metric measures the impact to integrity of a successfully exploited vulnerability.",
+  "values": [
+    {
+      "key": "N",
+      "name": "None",
+      "description": "There is no loss of integrity within the Vulnerable System."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "description": "Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is limited. The data modification does not have a direct, serious impact to the Vulnerable System."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "description": "There is a total loss of integrity, or a complete loss of protection."
+    },
+    {
+      "key": "X",
+      "name": "Not Defined",
+      "description": "This metric value is not defined. See CVSS documentation for details."
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 mkdocs==1.6.1
-mkdocs-bibtex==4.2.1
+mkdocs-bibtex==4.2.2
 mkdocs-include-markdown-plugin==7.1.4
 mkdocs-table-reader-plugin==3.1.0
-mkdocs-material==9.6.5
+mkdocs-material==9.6.7
 mkdocs-material-extensions==1.3.1
 mkdocstrings==0.28.2
 mkdocstrings-python==1.16.2


### PR DESCRIPTION
This is a quick patch to fix a post-deployment bug in the python path when the site tries to build.

Examples are currently failing to render at site build time because mkdocs doesn't know where to find the `ssvc` module.

See change in `.github/workflows/deploy_site.yml`

Once deployed and we confirm it works, #729 should be closed