### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build Site
         run: |
-          export PYTHONPATH=./src;$PYTHONPATH
+          export PYTHONPATH=src:$PYTHONPATH
           mkdocs build --verbose --clean --config-file mkdocs.yml       
 
       - name: Upload artifact


### PR DESCRIPTION
This is a backport of a manual change to the publish branch subsequent to #731 to fix a typo (`;` &rarr; `:`)