### PR TITLE
Add NameSpace Enum

### DIFF
--- a/data/schema/v1/Decision_Point-1-0-1.schema.json
+++ b/data/schema/v1/Decision_Point-1-0-1.schema.json
@@ -48,7 +48,7 @@
 		"namespace": {
 		    "type": "string",
 		    "description": "Namespace (a short, unique string): For example, \"ssvc\" or \"cvss\" to indicate the source of the decision point. See SSVC Documentation for details.",
-		    "pattern": "^[a-z0-9-]{3,4}[a-z0-9/\\.-]*$",
+		    "pattern": "^(x_)?[a-z0-9-]{3,4}[a-z0-9/\\.-]*$",
 		    "examples": ["ssvc", "cvss", "ssvc-jp", "ssvc/acme", "ssvc/example.com"]
 		},
 		"version": {

--- a/src/ssvc/_mixins.py
+++ b/src/ssvc/_mixins.py
@@ -20,6 +20,7 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict, field_validator
 from semver import Version
 
+from ssvc.namespaces import NamespaceValidator
 from . import _schemaVersion
 
 
@@ -54,7 +55,12 @@ class _Namespaced(BaseModel):
     Mixin class for namespaced SSVC objects.
     """
 
-    namespace: str = "ssvc"
+    namespace: str
+
+    @field_validator("namespace", mode="before")
+    @classmethod
+    def validate_namespace(cls, value):
+        return NamespaceValidator.validate(value)
 
 
 class _Keyed(BaseModel):

--- a/src/ssvc/decision_points/base.py
+++ b/src/ssvc/decision_points/base.py
@@ -21,6 +21,7 @@ import logging
 from pydantic import BaseModel
 
 from ssvc._mixins import _Base, _Keyed, _Namespaced, _Versioned
+from ssvc.namespaces import NameSpace
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,7 @@ class SsvcDecisionPoint(_Base, _Keyed, _Versioned, _Namespaced, BaseModel):
     Models a single decision point as a list of values.
     """
 
+    namespace: str = NameSpace.SSVC
     values: list[SsvcDecisionPointValue] = []
 
     def __iter__(self):

--- a/src/ssvc/decision_points/cvss/base.py
+++ b/src/ssvc/decision_points/cvss/base.py
@@ -18,6 +18,7 @@ Provides a base class for modeling CVSS vector metrics as SSVC decision points.
 from pydantic import BaseModel
 
 from ssvc.decision_points.base import SsvcDecisionPoint
+from ssvc.namespaces import NameSpace
 
 
 class CvssDecisionPoint(SsvcDecisionPoint, BaseModel):
@@ -25,4 +26,4 @@ class CvssDecisionPoint(SsvcDecisionPoint, BaseModel):
     Models a single CVSS decision point as a list of values.
     """
 
-    namespace: str = "cvss"
+    namespace: NameSpace = NameSpace.CVSS

--- a/src/ssvc/namespaces.py
+++ b/src/ssvc/namespaces.py
@@ -23,6 +23,10 @@ X_PFX = "x_"
 
 
 class NameSpace(StrEnum):
+    """
+    Defines the official namespaces for SSVC.
+    """
+
     # auto() is used to automatically assign values to the members.
     # when used in a StrEnum, auto() assigns the lowercase name of the member as the value
     SSVC = auto()
@@ -34,6 +38,19 @@ class NamespaceValidator:
 
     @classmethod
     def validate(cls, value: str) -> str:
+        """
+        Validate the namespace value. The value must be one of the official namespaces or start with 'x_'.
+
+        Args:
+            value: a string representing a namespace
+
+        Returns:
+            the validated namespace value
+
+        Raises:
+            ValueError: if the value is not a valid namespace
+
+        """
         if value in NameSpace.__members__.values():
             return value
         if value.startswith(X_PFX):

--- a/src/ssvc/namespaces.py
+++ b/src/ssvc/namespaces.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""
+Provides a namespace enum
+"""
+#  Copyright (c) 2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Stakeholder Specific Vulnerability Categorization (SSVC) is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from enum import StrEnum, auto
+
+# extensions / experimental namespaces should start with the following prefix
+# this is to avoid conflicts with official namespaces
+X_PFX = "x_"
+
+
+class NameSpace(StrEnum):
+    # auto() is used to automatically assign values to the members.
+    # when used in a StrEnum, auto() assigns the lowercase name of the member as the value
+    SSVC = auto()
+    CVSS = auto()
+
+
+class NamespaceValidator:
+    """Custom type for validating namespaces."""
+
+    @classmethod
+    def validate(cls, value: str) -> str:
+        if value in NameSpace.__members__.values():
+            return value
+        if value.startswith(X_PFX):
+            return value
+        raise ValueError(
+            f"Invalid namespace: {value}. Must be one of {[ns.value for ns in NameSpace]} or start with '{X_PFX}'."
+        )
+
+    def __get_validators__(cls):
+        yield cls.validate
+
+
+def main():
+    for ns in NameSpace:
+        print(ns)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/test_doc_helpers.py
+++ b/src/test/test_doc_helpers.py
@@ -20,18 +20,14 @@ from ssvc.doc_helpers import example_block, markdown_table
 class MyTestCase(unittest.TestCase):
     def setUp(self):
         self.dp = SsvcDecisionPoint(
-            namespace="test",
+            namespace="x_test",
             name="test name",
             description="test description",
             key="TK",
             version="1.0.0",
             values=(
-                SsvcDecisionPointValue(
-                    name="A", key="A", description="A Definition"
-                ),
-                SsvcDecisionPointValue(
-                    name="B", key="B", description="B Definition"
-                ),
+                SsvcDecisionPointValue(name="A", key="A", description="A Definition"),
+                SsvcDecisionPointValue(name="B", key="B", description="B Definition"),
             ),
         )
 

--- a/src/test/test_dp_base.py
+++ b/src/test/test_dp_base.py
@@ -34,7 +34,7 @@ class MyTestCase(unittest.TestCase):
             key="bar",
             description="baz",
             version="1.0.0",
-            namespace="name1",
+            namespace="x_test",
             values=tuple(self.values),
         )
 
@@ -64,7 +64,7 @@ class MyTestCase(unittest.TestCase):
             key="asdfasdf",
             description="asdfasdf",
             version="1.33.1",
-            namespace="asdfasdf",
+            namespace="x_test",
             values=self.values,
         )
 
@@ -90,7 +90,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(obj.key, "bar")
         self.assertEqual(obj.description, "baz")
         self.assertEqual(obj.version, "1.0.0")
-        self.assertEqual(obj.namespace, "name1")
+        self.assertEqual(obj.namespace, "x_test")
         self.assertEqual(len(self.values), len(obj.values))
 
     def test_ssvc_value_json_roundtrip(self):

--- a/src/test/test_mixins.py
+++ b/src/test/test_mixins.py
@@ -70,21 +70,22 @@ class TestMixins(unittest.TestCase):
         self.assertEqual(obj2.name, "quux")
         self.assertEqual(obj2.description, "baz")
 
-    def test_namespaced_create(self):
+    def test_namespaced_create_errors(self):
         # error if no namespace given
         with self.assertRaises(ValidationError):
             _Namespaced()
-
-        # use the official namespace values
-        for ns in NameSpace:
-            obj = _Namespaced(namespace=ns)
-            self.assertEqual(obj.namespace, ns)
 
         # error if namespace is not in the enum
         # and it doesn't start with x_
         self.assertNotIn("quux", NameSpace)
         with self.assertRaises(ValidationError):
             _Namespaced(namespace="quux")
+
+    def test_namespaced_create(self):
+        # use the official namespace values
+        for ns in NameSpace:
+            obj = _Namespaced(namespace=ns)
+            self.assertEqual(obj.namespace, ns)
 
         # custom namespaces are allowed as long as they start with x_
         for _ in range(100):


### PR DESCRIPTION
This PR adds a `NameSpace` string enumeration that will define the "official" valid namespaces for SSVC objects. Currently that is just "ssvc" and "cvss", but, for example, #707 would be another candidate to add one.

It also addresses [this comment](https://github.com/CERTCC/SSVC/issues/703#issuecomment-2692390187) in #703, which asks:

> Could we please agree on that local/private namespaces start with `x_ `?

by including validation support for both: specific namespace strings in the enum, and any string starting with `x_`.

This is not a complete fix for #703, however, as there is also a request in [this other comment](https://github.com/CERTCC/SSVC/issues/703#issuecomment-2672748363) to include a url of the JSON list. At the moment, that's bigger than I can bite off, but I wanted to at least get started on the enumeration aspects in this PR.

We should decide when we go to merge this whether we want to keep #703 open or close it with this PR and leave the [url request](https://github.com/CERTCC/SSVC/issues/703#issuecomment-2672748363) comment behind as a separate issue to extend it. If we keep #703 open, we should spawn sub-issues from it so that we can record the fact that this PR partially addressed it.

## Copilot Summary

This pull request introduces several changes to the SSVC (Stakeholder Specific Vulnerability Categorization) project, focusing on namespace validation and the introduction of a new `NamespaceValidator` class. The most important changes include modifying the namespace pattern in the schema, updating the namespace handling in various classes, and adding new tests to ensure proper namespace validation.

### Namespace Validation Enhancements:

* [`data/schema/v1/Decision_Point-1-0-1.schema.json`](diffhunk://#diff-37fef1e05e020eda394600d8c7c4b8c22add53a9275d5ca0106313502c8bf9c3L51-R51): Updated the `namespace` pattern to allow for optional `x_` prefix for experimental namespaces.
* [`src/ssvc/_mixins.py`](diffhunk://#diff-3e266c8592982d40cd5b33b96e21eaa4399524f834f5d2a239c0a5e0e65fc788R23): Added a `NamespaceValidator` class and used it to validate the `namespace` field in the `_Namespaced` class. [[1]](diffhunk://#diff-3e266c8592982d40cd5b33b96e21eaa4399524f834f5d2a239c0a5e0e65fc788R23) [[2]](diffhunk://#diff-3e266c8592982d40cd5b33b96e21eaa4399524f834f5d2a239c0a5e0e65fc788L57-R63)
* [`src/ssvc/decision_points/base.py`](diffhunk://#diff-ac209de0ccc0f2a6ffce94a0ddc8492a6b9b5df1439abd0114182482448a5522R24): Updated the `namespace` field in the `SsvcDecisionPoint` class to use the `NameSpace` enum. [[1]](diffhunk://#diff-ac209de0ccc0f2a6ffce94a0ddc8492a6b9b5df1439abd0114182482448a5522R24) [[2]](diffhunk://#diff-ac209de0ccc0f2a6ffce94a0ddc8492a6b9b5df1439abd0114182482448a5522R70)
* [`src/ssvc/decision_points/cvss/base.py`](diffhunk://#diff-0c474c599929d1d5db54ed44d42e06431714336c52ba67c02fc9617bbe2bc829R21-R29): Updated the `namespace` field in the `CvssDecisionPoint` class to use the `NameSpace` enum.
* [`src/ssvc/namespaces.py`](diffhunk://#diff-1aad7413563e80b33f7897c1678fa91a207d3aab5b5c67619996a6c73aadcfe5R1-R72): Added a new file defining the `NameSpace` enum and `NamespaceValidator` class for validating namespaces.

### Test Updates:

* [`src/test/test_doc_helpers.py`](diffhunk://#diff-4f37e8f5022c7b05ef0d3726177dae16af650016290c2142cf581b9ab2fe3c1bL23-R30): Updated test cases to use the `x_` prefix for custom namespaces.
* [`src/test/test_dp_base.py`](diffhunk://#diff-8db0beacde4ead52a8da269224e4fbb78b6f7c38d801bf36ccb201ad3f6bcbe1L37-R37): Updated test cases to use the `x_` prefix for custom namespaces. [[1]](diffhunk://#diff-8db0beacde4ead52a8da269224e4fbb78b6f7c38d801bf36ccb201ad3f6bcbe1L37-R37) [[2]](diffhunk://#diff-8db0beacde4ead52a8da269224e4fbb78b6f7c38d801bf36ccb201ad3f6bcbe1L67-R67) [[3]](diffhunk://#diff-8db0beacde4ead52a8da269224e4fbb78b6f7c38d801bf36ccb201ad3f6bcbe1L93-R93)
* [`src/test/test_mixins.py`](diffhunk://#diff-17c1dac0c54843fc57f58fb2c599c35e141a990367dbcd4c2905fd5e2d9ee85aR15-R20): Added new tests to verify namespace validation, including tests for official and custom namespaces. [[1]](diffhunk://#diff-17c1dac0c54843fc57f58fb2c599c35e141a990367dbcd4c2905fd5e2d9ee85aR15-R20) [[2]](diffhunk://#diff-17c1dac0c54843fc57f58fb2c599c35e141a990367dbcd4c2905fd5e2d9ee85aL71-R95) [[3]](diffhunk://#diff-17c1dac0c54843fc57f58fb2c599c35e141a990367dbcd4c2905fd5e2d9ee85aL97-R125)

