### PR TITLE
Pin tj-actions/changed-files action to a specific sha1

### DIFF
--- a/.github/workflows/lint_md_changes.yml
+++ b/.github/workflows/lint_md_changes.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: tj-actions/changed-files@v45
+    - uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
       id: changed-files
       with:
         files: '**/*.md'


### PR DESCRIPTION
On review of the recent `tj-actions/changed-files` [compromise](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066) we determined that while the `.github/workflows/lint_md_changes.yml` did point to one of the affected tags, the workflow does not involve any secrets so there was no impact to the project.

However, in the interest of protecting against any future regression, this PR pins the action to a specific sha1 hash instead of a version tag, as the version tags were also compromised in the above incident.

See original issue in tj-actions/changed-files#2463