### PR TITLE
Simplify Makefile / Dockerfile interactions using docker-compose.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,9 @@
 # Project-specific vars
-PFX=ssvc
-DOCKER=docker
-DOCKER_BUILD=$(DOCKER) build
-DOCKER_RUN=$(DOCKER) run --tty --rm
-PROJECT_VOLUME=--volume $(shell pwd):/app
 MKDOCS_PORT=8765
-
-# docker names
-TEST_DOCKER_TARGET=test
-TEST_IMAGE = $(PFX)_test
-DOCS_DOCKER_TARGET=docs
-DOCS_IMAGE = $(PFX)_docs
+DOCKER_DIR=docker
 
 # Targets
-.PHONY: all dockerbuild_test dockerrun_test dockerbuild_docs dockerrun_docs docs docker_test clean help
+.PHONY: all test docs docker_test clean help
 
 all: help
 
@@ -21,29 +11,29 @@ mdlint_fix:
 	@echo "Running markdownlint..."
 	markdownlint --config .markdownlint.yml --fix .
 
-dockerbuild_test:
-	@echo "Building the test Docker image..."
-	$(DOCKER_BUILD) --target $(TEST_DOCKER_TARGET) --tag $(TEST_IMAGE) .
+test:
+	@echo "Running tests locally..."
+	pytest -v src/test
 
-dockerrun_test:
-	@echo "Running the test Docker image..."
-	$(DOCKER_RUN) $(PROJECT_VOLUME) $(TEST_IMAGE)
+docker_test:
+	@echo "Running tests in Docker..."
+	pushd $(DOCKER_DIR) && docker-compose run --rm test
 
-dockerbuild_docs:
-	@echo "Building the docs Docker image..."
-	$(DOCKER_BUILD) --target $(DOCS_DOCKER_TARGET) --tag $(DOCS_IMAGE) .
+docs:
+	@echo "Building and running docs in Docker..."
+	pushd $(DOCKER_DIR) && docker-compose up docs
 
-dockerrun_docs:
-	@echo "Running the docs Docker image..."
-	$(DOCKER_RUN) --publish $(MKDOCS_PORT):8000 $(PROJECT_VOLUME) $(DOCS_IMAGE)
+up:
+	@echo "Starting Docker services..."
+	pushd $(DOCKER_DIR) && docker-compose up -d
 
-
-docs: dockerbuild_docs dockerrun_docs
-docker_test: dockerbuild_test dockerrun_test
+down:
+	@echo "Stopping Docker services..."
+	pushd $(DOCKER_DIR) && docker-compose down
 
 clean:
-	@echo "Cleaning up..."
-	$(DOCKER) rmi $(TEST_IMAGE) $(DOCS_IMAGE) || true
+	@echo "Cleaning up Docker resources..."
+	pushd $(DOCKER_DIR) && docker-compose down --rmi local || true
 
 help:
 	@echo "Usage: make [target]"
@@ -51,16 +41,8 @@ help:
 	@echo "Targets:"
 	@echo " all         - Display this help message"
 	@echo " mdlint_fix  - Run markdownlint with --fix"
-	@echo " docs        - Build and run the docs Docker image"
-	@echo " docker_test - Build and run the test Docker image"
-	@echo ""
-	@echo " dockerbuild_test - Build the test Docker image"
-	@echo " dockerrun_test   - Run the test Docker image"
-	@echo " dockerbuild_docs - Build the docs Docker image"
-	@echo " dockerrun_docs   - Run the docs Docker image"
-	@echo ""
-	@echo " clean - Remove the Docker images"
-	@echo " help  - Display this help message"
-
-
-
+	@echo " test        - Run the tests in a local shell"
+	@echo " docs        - Build and run the docs Docker service"
+	@echo " docker_test - Run the tests in a Docker container"
+	@echo " clean       - Remove Docker containers and images"
+	@echo " help        - Display this help message"

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ Then navigate to <http://localhost:8000/SSVC/> to see the site.
 We include a few tests for the `ssvc` module.
 Options for running the test suite are provided below.
 
-| Environment | Command |
-|-------------|---------|
-| Make, Docker | `make docker_test` |
-| ~~Make~~, Docker | `cd docker && docker-compose run -rm test` |
-| Make, ~~Docker~~ | `make test` |
-| ~~Make~~, ~~Docker~~ | `pytest src/test` |
+| Environment | Command | Comment |
+|-------------|---------|---------|
+| Make, Docker | `make docker_test` | runs in docker container |
+| ~~Make~~, Docker | `cd docker && docker-compose run -rm test` | runs in docker container |
+| Make, ~~Docker~~ | `make test` | runs in host OS |
+| ~~Make~~, ~~Docker~~ | `pytest src/test` | runs in host OS |
 
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -116,68 +116,30 @@ To preview any `make` command without actually executing it, run:
 make -n <command>
 ```
 
-### Run Local Docs Server With Docker
+### Run Local Docs Server
 
-The easiest way to get started is using make to build a docker image and run the site:
+The easiest way to get started is using make to build a docker image and run the site. However, we provide a few other options below.
 
-```bash
-make docs
-```
+| Environment | Command |
+|-------------|---------|
+| Make, Docker | `make docs` |
+| ~~Make~~, Docker | `cd docker && docker-compose up docs` |
+| ~~Make~~, ~~Docker~~ | `mkdocs serve` |
 
 Then navigate to <http://localhost:8000/SSVC/> to see the site.
-
-Or, if make is not available:
-
-```bash
-cd docker && docker-compose up docs
-```
-
-### Run Local Server Without Docker
-
-If you prefer to run the site locally without Docker, you can do so with mkdocs.
-We recommend using a virtual environment to manage dependencies:
-
-```bash
-python3 -m venv ssvc_venv
-pip install -r requirements.txt
-```
-
-Start a local server:
-
-```bash
-mkdocs serve
-```
-
-By default, the server will run on port 8001.
-This is configured in the `mkdocs.yml` file.
-Navigate to <http://localhost:8001/> to see the site.
-
-(Hint: You can use the `--dev-addr` argument with mkdocs to change the port, e.g. `mkdocs serve --dev-addr localhost:8000`)
 
 ## Run tests
 
 We include a few tests for the `ssvc` module.
+Options for running the test suite are provided below.
 
-### Run Tests With Docker
+| Environment | Command |
+|-------------|---------|
+| Make, Docker | `make docker_test` |
+| ~~Make~~, Docker | `cd docker && docker-compose run -rm test` |
+| Make, ~~Docker~~ | `make test` |
+| ~~Make~~, ~~Docker~~ | `pytest src/test` |
 
-The easiest way to run tests is using make to build a docker image and run the tests:
-
-```bash
-make docker_test
-```
-
-Or, if make is not available:
-
-```bash
-cd docker && docker-compose up test
-```
-
-### Run Tests Without Docker
-
-```bash
-pip install pytest
-pytest src/test
-```
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ These json files are generated examples from the python `ssvc` module.
 
 These files are used by the `ssvc-calc` module.
 
+## `/docker/*`
+
+The `docker` directory contains Dockerfiles and related configurations for to
+create images that can run the SSVC documentation site and unit tests.
+
+Example:
+
+```bash
+cd docker
+docker-compose up test
+docker-compose up docs
+```
+
 ## `/src/*`
 
 This directory holds helper scripts that can make managing or using SSVC easier.
@@ -103,7 +116,7 @@ To preview any `make` command without actually executing it, run:
 make -n <command>
 ```
 
-### Run Local Server With Docker
+### Run Local Docs Server With Docker
 
 The easiest way to get started is using make to build a docker image and run the site:
 
@@ -111,18 +124,12 @@ The easiest way to get started is using make to build a docker image and run the
 make docs
 ```
 
-Then navigate to <http://localhost:8765/SSVC/> to see the site.
-
-Note that the docker container will display a message with the URL to visit, for
-example: `Serving on http://0.0.0.0:8000/SSVC/` in the output. However, that port
-is only available inside the container. The host port 8765 is mapped to the container's
-port 8000, so you should navigate to <http://localhost:8765/SSVC/> to see the site.
+Then navigate to <http://localhost:8000/SSVC/> to see the site.
 
 Or, if make is not available:
 
 ```bash
-docker build --target docs --tag ssvc_docs .
-docker run --tty --rm -p 8765:8000 --volume .:/app ssvc_docs
+cd docker && docker-compose up docs
 ```
 
 ### Run Local Server Without Docker
@@ -162,8 +169,7 @@ make docker_test
 Or, if make is not available:
 
 ```bash
-docker build --target test --tag ssvc_test .
-docker run --tty --rm --volume .:/app ssvc_test
+cd docker && docker-compose up test
 ```
 
 ### Run Tests Without Docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,10 +5,10 @@ WORKDIR /app
 FROM base AS dependencies
 
 # install requirements
-COPY requirements.txt .
+COPY ../requirements.txt .
 RUN pip install -r requirements.txt
 # Copy the files we need
-COPY . /app
+COPY .. /app
 # Set the environment variable
 ENV PYTHONPATH=/app/src
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  base:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: base
+    image: base:latest
+
+  dependencies:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: dependencies
+    image: dependencies:latest
+    depends_on:
+      - base
+
+  test:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: test
+    image: test:latest
+    depends_on:
+      - dependencies
+
+  docs:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: docs
+    image: docs:latest
+    depends_on:
+      - dependencies
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
This PR refactors our use of `make` and `docker` to use `docker-compose`, which simplifies the process for building and running container images. This will be useful as a foundation for future architectures where we need to spin up more containers for microservices, as we begin to address things like #655.

## CoPilot Summary

This pull request refactors the project's Docker setup to simplify workflows and improve maintainability. Key changes include replacing individual `Makefile` Docker commands with `docker-compose` commands, reorganizing Docker-related files into a dedicated `docker` directory, and updating documentation to reflect these changes.

### Docker Setup Refactoring:

* **Makefile Changes**: Removed individual Docker build and run targets (`dockerbuild_test`, `dockerrun_test`, `dockerbuild_docs`, `dockerrun_docs`) in favor of consolidated `docker-compose` commands (`docker_test`, `docs`, `up`, `down`). Updated help text to reflect the new commands.
* **Dockerfile Updates**: Moved `Dockerfile` to a dedicated `docker` directory and updated paths for requirements and application files to reflect the new directory structure.
* **`docker-compose.yml` Addition**: Added a `docker-compose.yml` file to define services (`base`, `dependencies`, `test`, `docs`) and streamline Docker workflows.

### Documentation Updates:

* **Docker Directory Description**: Added a new section to `README.md` describing the `docker` directory and its purpose for managing Docker configurations.
* **Updated Commands**: Replaced outdated Docker commands with `docker-compose` equivalents in sections for running the documentation server (`make docs`) and tests (`make docker_test`). Adjusted port mapping details for the docs server. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L165-R172)