### PR TITLE
Update CISA Track* to Monitor and version

### DIFF
--- a/src/ssvc/outcomes/cisa/scoring.py
+++ b/src/ssvc/outcomes/cisa/scoring.py
@@ -33,6 +33,14 @@ _TRACK_STAR = DecisionPointValue(
     "CISA recommends remediating Track* vulnerabilities within standard update timelines.",
 )
 
+
+_MONITOR = DecisionPointValue(
+    name="Monitor",
+    key="M",
+    description="The vulnerability contains specific characteristics that may require closer monitoring for changes. "
+    "CISA recommends remediating Monitor vulnerabilities within standard update timelines.",
+)
+
 _ATTEND = DecisionPointValue(
     name="Attend",
     key="A",
@@ -50,7 +58,7 @@ _ACT = DecisionPointValue(
     "CISA recommends remediating Act vulnerabilities as soon as possible.",
 )
 
-CISA = CisaDecisionPoint(
+CISA1 = CisaDecisionPoint(
     name="CISA Levels",
     key="CISA",
     description="The CISA outcome group. "
@@ -63,13 +71,27 @@ CISA = CisaDecisionPoint(
         _ACT,
     ),
 )
+
+CISA2 = CisaDecisionPoint(
+    name="CISA Levels",
+    key="CISA",
+    description="The CISA outcome group. "
+    "CISA uses its own SSVC decision tree model to prioritize relevant vulnerabilities into four possible decisions: Track, Track*, Attend, and Act.",
+    version="1.0.1",
+    values=(
+        _TRACK,
+        _MONITOR,
+        _ATTEND,
+        _ACT,
+    ),
+)
 """
 The CISA outcome group. Based on CISA's customizations of the SSVC model.
 See https://www.cisa.gov/stakeholder-specific-vulnerability-categorization-ssvc
 """
 
 
-VERSIONS = (CISA,)
+VERSIONS = (CISA2,)
 LATEST = VERSIONS[-1]
 
 


### PR DESCRIPTION
- resolves #699

CISA uses 2.0.3 for the Decision Table Version as the current one in various places. The next version 2.0.4 is expected to get rid of Track* in favor of the Monitor as guidance provided by Jono in May 2025.
