### PR TITLE
Add Coordinator Publish DecisionTable

### DIFF
--- a/data/json/decision_tables/ssvc/coordinator_publish_decision_table_1_0_0.json
+++ b/data/json/decision_tables/ssvc/coordinator_publish_decision_table_1_0_0.json
@@ -1,0 +1,270 @@
+{
+  "namespace": "ssvc",
+  "key": "DT_COORD_PUBLISH",
+  "version": "1.0.0",
+  "name": "Coordinator Publish Decision Table",
+  "description": "This decision table is used to determine the priority of a coordinator publish.",
+  "schemaVersion": "2.0.0",
+  "decision_points": {
+    "ssvc:SINV:1.0.0": {
+      "namespace": "ssvc",
+      "key": "SINV",
+      "version": "1.0.0",
+      "name": "Supplier Involvement",
+      "description": "What is the state of the supplier’s work on addressing the vulnerability?",
+      "schemaVersion": "2.0.0",
+      "values": [
+        {
+          "key": "FR",
+          "name": "Fix Ready",
+          "description": "The supplier has provided a patch or fix."
+        },
+        {
+          "key": "C",
+          "name": "Cooperative",
+          "description": "The supplier is actively generating a patch or fix; they may or may not have provided a mitigation or work-around in the mean time."
+        },
+        {
+          "key": "UU",
+          "name": "Uncooperative/Unresponsive",
+          "description": "The supplier has not responded, declined to generate a remediation, or no longer exists."
+        }
+      ]
+    },
+    "ssvc:E:1.1.0": {
+      "namespace": "ssvc",
+      "key": "E",
+      "version": "1.1.0",
+      "name": "Exploitation",
+      "description": "The present state of exploitation of the vulnerability.",
+      "schemaVersion": "2.0.0",
+      "values": [
+        {
+          "key": "N",
+          "name": "None",
+          "description": "There is no evidence of active exploitation and no public proof of concept (PoC) of how to exploit the vulnerability."
+        },
+        {
+          "key": "P",
+          "name": "Public PoC",
+          "description": "One of the following is true: (1) Typical public PoC exists in sources such as Metasploit or websites like ExploitDB; or (2) the vulnerability has a well-known method of exploitation."
+        },
+        {
+          "key": "A",
+          "name": "Active",
+          "description": "Shared, observable, reliable evidence that the exploit is being used in the wild by real attackers; there is credible public reporting."
+        }
+      ]
+    },
+    "ssvc:PVA:1.0.0": {
+      "namespace": "ssvc",
+      "key": "PVA",
+      "version": "1.0.0",
+      "name": "Public Value Added",
+      "description": "How much value would a publication from the coordinator benefit the broader community?",
+      "schemaVersion": "2.0.0",
+      "values": [
+        {
+          "key": "L",
+          "name": "Limited",
+          "description": "Minimal value added to the existing public information because existing information is already high quality and in multiple outlets."
+        },
+        {
+          "key": "A",
+          "name": "Ampliative",
+          "description": "Amplifies and/or augments the existing public information about the vulnerability, for example, adds additional detail, addresses or corrects errors in other public information, draws further attention to the vulnerability, etc."
+        },
+        {
+          "key": "P",
+          "name": "Precedence",
+          "description": "The publication would be the first publicly available, or be coincident with the first publicly available."
+        }
+      ]
+    },
+    "ssvc:PUBLISH:1.0.0": {
+      "namespace": "ssvc",
+      "key": "PUBLISH",
+      "version": "1.0.0",
+      "name": "Publish, Do Not Publish",
+      "description": "The publish outcome group.",
+      "schemaVersion": "2.0.0",
+      "values": [
+        {
+          "key": "N",
+          "name": "Do Not Publish",
+          "description": "Do Not Publish"
+        },
+        {
+          "key": "P",
+          "name": "Publish",
+          "description": "Publish"
+        }
+      ]
+    }
+  },
+  "outcome": "ssvc:PUBLISH:1.0.0",
+  "mapping": [
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "N"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "L",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "N",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "FR",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "A",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "P",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "C",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    },
+    {
+      "ssvc:SINV:1.0.0": "UU",
+      "ssvc:E:1.1.0": "A",
+      "ssvc:PVA:1.0.0": "P",
+      "ssvc:PUBLISH:1.0.0": "P"
+    }
+  ]
+}

--- a/data/json/ssvc_object_registry.json
+++ b/data/json/ssvc_object_registry.json
@@ -6699,6 +6699,284 @@
         "ssvc": {
           "namespace": "ssvc",
           "keys": {
+            "DT_COORD_PUBLISH": {
+              "key": "DT_COORD_PUBLISH",
+              "versions": {
+                "1.0.0": {
+                  "version": "1.0.0",
+                  "obj": {
+                    "namespace": "ssvc",
+                    "key": "DT_COORD_PUBLISH",
+                    "version": "1.0.0",
+                    "name": "Coordinator Publish Decision Table",
+                    "description": "This decision table is used to determine the priority of a coordinator publish.",
+                    "schemaVersion": "2.0.0",
+                    "decision_points": {
+                      "ssvc:SINV:1.0.0": {
+                        "namespace": "ssvc",
+                        "key": "SINV",
+                        "version": "1.0.0",
+                        "name": "Supplier Involvement",
+                        "description": "What is the state of the supplier’s work on addressing the vulnerability?",
+                        "schemaVersion": "2.0.0",
+                        "values": [
+                          {
+                            "key": "FR",
+                            "name": "Fix Ready",
+                            "description": "The supplier has provided a patch or fix."
+                          },
+                          {
+                            "key": "C",
+                            "name": "Cooperative",
+                            "description": "The supplier is actively generating a patch or fix; they may or may not have provided a mitigation or work-around in the mean time."
+                          },
+                          {
+                            "key": "UU",
+                            "name": "Uncooperative/Unresponsive",
+                            "description": "The supplier has not responded, declined to generate a remediation, or no longer exists."
+                          }
+                        ]
+                      },
+                      "ssvc:E:1.1.0": {
+                        "namespace": "ssvc",
+                        "key": "E",
+                        "version": "1.1.0",
+                        "name": "Exploitation",
+                        "description": "The present state of exploitation of the vulnerability.",
+                        "schemaVersion": "2.0.0",
+                        "values": [
+                          {
+                            "key": "N",
+                            "name": "None",
+                            "description": "There is no evidence of active exploitation and no public proof of concept (PoC) of how to exploit the vulnerability."
+                          },
+                          {
+                            "key": "P",
+                            "name": "Public PoC",
+                            "description": "One of the following is true: (1) Typical public PoC exists in sources such as Metasploit or websites like ExploitDB; or (2) the vulnerability has a well-known method of exploitation."
+                          },
+                          {
+                            "key": "A",
+                            "name": "Active",
+                            "description": "Shared, observable, reliable evidence that the exploit is being used in the wild by real attackers; there is credible public reporting."
+                          }
+                        ]
+                      },
+                      "ssvc:PVA:1.0.0": {
+                        "namespace": "ssvc",
+                        "key": "PVA",
+                        "version": "1.0.0",
+                        "name": "Public Value Added",
+                        "description": "How much value would a publication from the coordinator benefit the broader community?",
+                        "schemaVersion": "2.0.0",
+                        "values": [
+                          {
+                            "key": "L",
+                            "name": "Limited",
+                            "description": "Minimal value added to the existing public information because existing information is already high quality and in multiple outlets."
+                          },
+                          {
+                            "key": "A",
+                            "name": "Ampliative",
+                            "description": "Amplifies and/or augments the existing public information about the vulnerability, for example, adds additional detail, addresses or corrects errors in other public information, draws further attention to the vulnerability, etc."
+                          },
+                          {
+                            "key": "P",
+                            "name": "Precedence",
+                            "description": "The publication would be the first publicly available, or be coincident with the first publicly available."
+                          }
+                        ]
+                      },
+                      "ssvc:PUBLISH:1.0.0": {
+                        "namespace": "ssvc",
+                        "key": "PUBLISH",
+                        "version": "1.0.0",
+                        "name": "Publish, Do Not Publish",
+                        "description": "The publish outcome group.",
+                        "schemaVersion": "2.0.0",
+                        "values": [
+                          {
+                            "key": "N",
+                            "name": "Do Not Publish",
+                            "description": "Do Not Publish"
+                          },
+                          {
+                            "key": "P",
+                            "name": "Publish",
+                            "description": "Publish"
+                          }
+                        ]
+                      }
+                    },
+                    "outcome": "ssvc:PUBLISH:1.0.0",
+                    "mapping": [
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "N"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "L",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "N",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "FR",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "A",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "P",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "C",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      },
+                      {
+                        "ssvc:SINV:1.0.0": "UU",
+                        "ssvc:E:1.1.0": "A",
+                        "ssvc:PVA:1.0.0": "P",
+                        "ssvc:PUBLISH:1.0.0": "P"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
             "DT_DP": {
               "key": "DT_DP",
               "versions": {

--- a/src/ssvc/decision_tables/ssvc/coord_pub_dt.py
+++ b/src/ssvc/decision_tables/ssvc/coord_pub_dt.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+"""
+Provides the Coordinator Publish Decision Table for SSVC.
+"""
+
+#  Copyright (c) 2025 Carnegie Mellon University.
+#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE
+#  ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+#  CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND,
+#  EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT
+#  NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR
+#  MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE
+#  OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE
+#  ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM
+#  PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#  Licensed under a MIT (SEI)-style license, please see LICENSE or contact
+#  permission@sei.cmu.edu for full terms.
+#  [DISTRIBUTION STATEMENT A] This material has been approved for
+#  public release and unlimited distribution. Please see Copyright notice
+#  for non-US Government use and distribution.
+#  This Software includes and/or makes use of Third-Party Software each
+#  subject to its own license.
+#  DM24-0278
+
+from ssvc.decision_points.ssvc.exploitation import LATEST as Exploitation
+from ssvc.decision_points.ssvc.public_value_added import LATEST as PublicValueAdded
+from ssvc.decision_points.ssvc.supplier_involvement import LATEST as SupplierInvolvement
+from ssvc.decision_tables.base import DecisionTable
+from ssvc.namespaces import NameSpace
+from ssvc.outcomes.ssvc.publish import LATEST as Priority
+
+V1_0_0 = DecisionTable(
+    namespace=NameSpace.SSVC,
+    key="COORD_PUBLISH",
+    version="1.0.0",
+    name="Coordinator Publish Decision Table",
+    description="This decision table is used to determine the priority of a coordinator publish.",
+    decision_points={
+        dp.id: dp
+        for dp in [SupplierInvolvement, Exploitation, PublicValueAdded, Priority]
+    },
+    outcome=Priority.id,
+    mapping=[
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "N",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "L",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "N",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "FR",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "A",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "P",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "C",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+        {
+            "ssvc:SINV:1.0.0": "UU",
+            "ssvc:E:1.1.0": "A",
+            "ssvc:PVA:1.0.0": "P",
+            "ssvc:PUBLISH:1.0.0": "P",
+        },
+    ],
+)
+
+VERSIONS = (V1_0_0,)
+LATEST = VERSIONS[-1]
+
+
+def main():
+    from ssvc.decision_tables.base import decision_table_to_longform_df
+
+    print(LATEST.model_dump_json(indent=2))
+
+    print("Longform DataFrame CSV")
+    print()
+    print(decision_table_to_longform_df(LATEST).to_csv(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I think I got this right. The default generated mapping was pretty close, and I only had to change one or two outcome lines. It passes the check now. There are no changes to the content as published as a result, so I don't think we had a problem with this tree, not sure why it didn't work on a previous attempt (ref: #842)

## Copilot Summary

This pull request adds a new decision table for coordinator publication prioritization to the SSVC (Stakeholder-Specific Vulnerability Categorization) data model. The new table, along with its supporting metadata, is now available in the object registry, enabling its use in decision support workflows.

**New Coordinator Publish Decision Table:**

* Added the `Coordinator Publish Decision Table` version 1.0.0 as `DT_COORD_PUBLISH` in both the data files and the SSVC object registry. This table determines the priority of a coordinator's decision to publish based on factors such as supplier involvement, exploitation status, and public value added. [[1]](diffhunk://#diff-ac87d32348aea46995a8cbe6c99e39317be6368dd7a4a1b113eff7ddcb33cbaaR1-R270) [[2]](diffhunk://#diff-dfa090915974450f002f695e3f15f988b5f70e69781f4436a3b9de083a8d897dR6702-R6979)

**Registry Integration:**

* Registered the new decision table (`DT_COORD_PUBLISH` v1.0.0) in `ssvc_object_registry.json`, making it accessible for lookups and use throughout the system.

**Decision Logic and Mapping:**

* Defined the decision points (`Supplier Involvement`, `Exploitation`, `Public Value Added`) and their possible values, as well as the mapping logic that determines whether to publish or not based on combinations of these factors. [[1]](diffhunk://#diff-ac87d32348aea46995a8cbe6c99e39317be6368dd7a4a1b113eff7ddcb33cbaaR1-R270) [[2]](diffhunk://#diff-dfa090915974450f002f695e3f15f988b5f70e69781f4436a3b9de083a8d897dR6702-R6979)