### PR TITLE
Add 'invalid' to the registered namespaces

### DIFF
--- a/src/ssvc/namespaces.py
+++ b/src/ssvc/namespaces.py
@@ -61,7 +61,6 @@ class NameSpace(StrEnum):
     EXAMPLE = auto()
     TEST = auto()
     INVALID = auto()
-    X_INVALID = auto()
 
     @classmethod
     def validate(cls, value: str) -> str:
@@ -79,6 +78,13 @@ class NameSpace(StrEnum):
             ValueError: if the value is not a valid namespace
 
         """
+
+        if value in cls.__members__.values():
+            # value is an unadorned registered namespace
+            # so we're done
+            return value
+
+        # check against known pattern
         valid = NS_PATTERN.match(value)
 
         if valid:


### PR DESCRIPTION
- resolves #907 

The original issue also mentions `x_invalid`, however, if we add `x_invalid` to the registered namespaces, it will fail to match the namespace pattern because the pattern assumes anything that starts with `x_` will have a fragment. So I'm leaving that out of this PR in the interest of keeping the PR simple.
