### PR TITLE
Remove default volume mount in docker-compose config

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,8 +32,6 @@ services:
     image: docs:latest
     depends_on:
       - dependencies
-    volumes:
-      - ..:/app
     ports:
       - "8000:8000"
 
@@ -45,7 +43,5 @@ services:
     image: registry_api:latest
     depends_on:
       - dependencies
-    volumes:
-      - ..:/app
     ports:
       - "8001:8000"


### PR DESCRIPTION
Remove a default `volume` mount configuration from `docker-compose.yml` because it was causing bad interactions between the host system and the container when `uv` would rebuild the environment within the container. The MacOS dev host was flagging python libraries as untrusted after running the containers.

(cherry picked from commit 51f345e9840ccd0eafb44e68b4a1032fa7ddc4d9)

## Copilot Summary

This pull request makes small changes to the `docker/docker-compose.yml` file by removing the bind mount volumes from the `docs` and `registry_api` services. This means the application source code will no longer be mounted into these containers at runtime, likely to improve container isolation or deployment consistency.