### PR TITLE
Mark `ssvc.dp_groups.base` as deprecated

### DIFF
--- a/data/schema/v2/Decision_Point_Group-2-0-0.schema.json
+++ b/data/schema/v2/Decision_Point_Group-2-0-0.schema.json
@@ -1,6 +1,6 @@
 {
   "title": "DecisionPointGroup",
-  "description": "Models a group of decision points as a dictionary, keyed by their ID.",
+  "description": "**DEPRECATED:** `DecisionPointGroup` has been superseded by `DecisionTable`.\nNew development should use `DecisionTable` instead.\nWe are keeping this class around for backward compatibility, but it may be removed in future releases.\n\nModels a group of decision points as a dictionary, keyed by their ID.",
   "type": "object",
   "$defs": {
     "DecisionPoint": {

--- a/docs/reference/code/decision_point_groups.md
+++ b/docs/reference/code/decision_point_groups.md
@@ -5,9 +5,11 @@ specific purpose.
 
 With the introduction of [Decision Tables](decision_tables.md), 
 Decision Point groups are less important than they once were, and may be
-deprecated in a future release.
+removed in a future release.
 However, they can still be useful for documentation and
 for some programmatic uses.
+
+::: ssvc.dp_groups.base
 
 ## SSVC Decision Point Groups
 

--- a/src/ssvc/dp_groups/base.py
+++ b/src/ssvc/dp_groups/base.py
@@ -21,7 +21,13 @@
 
 """
 Provides a DecisionPointGroup object for use in SSVC.
+
+!!! warning "`ssvc.dp_groups` is deprecated"
+
+    This module is *deprecated*. New development should focus on [`ssvc.decision_tables`](decision_tables.md).
+
 """
+import warnings
 from collections.abc import MutableMapping
 from typing import Literal
 
@@ -39,12 +45,24 @@ class DecisionPointGroup(
     _Base, _SchemaVersioned, _Versioned, BaseModel, MutableMapping
 ):
     """
+    **DEPRECATED:** `DecisionPointGroup` has been superseded by `DecisionTable`.
+    New development should use `DecisionTable` instead.
+    We are keeping this class around for backward compatibility, but it may be removed in future releases.
+
     Models a group of decision points as a dictionary, keyed by their ID.
     """
 
     decision_points: dict[str, DecisionPoint]
 
     schemaVersion: Literal[SCHEMA_VERSION]
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated; use `DecisionTable` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
- resolves #918 

## Copilot Summary

This pull request deprecates the `DecisionPointGroup` class and related documentation, signaling that `DecisionTable` should be used for new development. The changes introduce clear warnings in the code, schema, and documentation to inform users about the deprecation and future removal plans.

Deprecation of `DecisionPointGroup`:

* Added deprecation notice to the `DecisionPointGroup` class docstring and constructor in `src/ssvc/dp_groups/base.py`, raising a `DeprecationWarning` when instantiated.
* Inserted a module-level warning in `src/ssvc/dp_groups/base.py` to inform users that `ssvc.dp_groups` is deprecated and to direct them to `ssvc.decision_tables`.

Schema and documentation updates:

* Updated the schema description in `data/schema/v2/Decision_Point_Group-2-0-0.schema.json` to mark `DecisionPointGroup` as deprecated and recommend using `DecisionTable` instead.
* Revised documentation in `docs/reference/code/decision_point_groups.md` to indicate that Decision Point groups may be removed in a future release and added a section marker for `ssvc.dp_groups.base`.