### PR TITLE
Allow base namespaces to have fragments (e.g., `ssvc#example`)

### DIFF
--- a/src/ssvc/namespaces.py
+++ b/src/ssvc/namespaces.py
@@ -79,12 +79,20 @@ class NameSpace(StrEnum):
         """
         valid = NS_PATTERN.match(value)
 
+        ext_sep = "/"
+        frag_sep = "#"
+
         if valid:
             # pattern matches, so we can proceed with further checks
             # partition always returns three parts: the part before the separator, the separator itself, and the part after the separator
-            (base_ns, _, extension) = value.partition("/")
+            (base_ns, _, extension) = value.partition(ext_sep)
             # and we don't care about the extension beyond the pattern match above
             # so base_ns is either the full value or the part before the first slash
+
+            # but base_ns might have a fragment
+            # so we need to split that off if present
+            if "#" in base_ns:
+                (base_ns, _, fragment) = base_ns.partition(frag_sep)
 
             if base_ns in cls.__members__.values():
                 # base_ns is a registered namespaces

--- a/src/test/test_namespaces.py
+++ b/src/test/test_namespaces.py
@@ -18,7 +18,6 @@
 #  DM24-0278
 
 import unittest
-import re
 
 from ssvc.namespaces import NameSpace
 from ssvc.utils.patterns import NS_PATTERN
@@ -88,6 +87,8 @@ class MyTestCase(unittest.TestCase):
             "x_example.test#bar",
             "x_example.test#baz",
             "x_example.test#quux",
+            "ssvc",
+            "ssvc#test",
         ]:
             self.assertEqual(ns, NameSpace.validate(ns))
 

--- a/src/test/test_namespaces_pattern.py
+++ b/src/test/test_namespaces_pattern.py
@@ -40,6 +40,8 @@ class TestNamespacePattern(unittest.TestCase):
             "cisa",
             "custom",  # not in enum, but valid for the pattern
             "abc",  # not in enum, but valid for the pattern
+            "ssvc#reference-arch-1",  # valid namespace with hash
+            "x_example.test#test",
             "x_example.test#test/",
             "x_example.test#test//.org.example#bar",
             "ssvc/de-DE/.org.example#reference-arch-1",  # valid BCP-47 tag, reverse domain notation, hash


### PR DESCRIPTION
This PR adds the ability to use "fragments" after a registered namespace. E.g., `ssvc#foo` or `cisa#bar`. This was the intent all along, we just hadn't been testing for it so we missed that while it passed the pattern, it did not pass the validator on the namespace class.

## Copilot Summary

This pull request enhances the namespace validation logic and expands the test coverage to handle namespace strings containing fragments (using `#`). The main updates improve how fragments are parsed and validated, ensuring that such cases are correctly recognized as valid namespaces.

**Validation logic improvements:**

* Updated `NameSpace.validate` to correctly handle and parse fragments in namespace strings by splitting on the fragment separator (`#`) before validation.

**Test coverage enhancements:**

* Added new test cases in `test_namespace_validator` to confirm that namespace strings with fragments (e.g., `ssvc#test`) are validated successfully.
* Extended the pattern test setup to include additional valid namespace examples with fragments, such as `ssvc#reference-arch-1` and `x_example.test#test`.

**Code cleanup:**

* Removed an unused import (`re`) from `test_namespaces.py` for clarity.