### PR TITLE
Update namespace documentation

### DIFF
--- a/data/json/decision_points/basic/probability_scale_in_5_weighted_levels_ascending_1_0_0.json
+++ b/data/json/decision_points/basic/probability_scale_in_5_weighted_levels_ascending_1_0_0.json
@@ -1,35 +1,35 @@
 {
   "namespace": "basic",
-  "key": "P_5X",
+  "key": "P_5W",
   "version": "1.0.0",
   "name": "Probability Scale in 5 weighted levels, ascending",
-  "definition": "A probability scale with finer resolution at both extremes, based on NIST SP 800-30 Rev. 1 Appendix G",
+  "definition": "A probability scale with higher resolution as probability increases",
   "schemaVersion": "2.0.0",
   "values": [
     {
-      "key": "VL",
-      "name": "Very Low",
-      "definition": "0% <= Probability < 5%. Highly unlikely."
+      "key": "P0_30",
+      "name": "Less than 30%",
+      "definition": "Probability < 0.3"
     },
     {
-      "key": "L",
-      "name": "Low",
-      "definition": "5% <= Probability < 21%. Unlikely."
+      "key": "P30_55",
+      "name": "30% to 55%",
+      "definition": "0.3 <= Probability < 0.55"
     },
     {
-      "key": "M",
-      "name": "Moderate",
-      "definition": "21% <= Probability < 80%. Somewhat likely."
+      "key": "P55_75",
+      "name": "55% to 75%",
+      "definition": "0.55 <= Probability < 0.75"
     },
     {
-      "key": "H",
-      "name": "High",
-      "definition": "80% <= Probability < 96%. Highly likely."
+      "key": "P75_90",
+      "name": "75% to 90%",
+      "definition": "0.75 <= Probability < 0.9"
     },
     {
-      "key": "VH",
-      "name": "Very High",
-      "definition": "96% <= Probability <= 100%. Almost certain."
+      "key": "P90_100",
+      "name": "Greater than 90%",
+      "definition": "0.9 <= Probability <= 1.0"
     }
   ]
 }

--- a/data/json/decision_points/nist_800_30/probability_scale_in_5_weighted_levels_ascending_1_0_0.json
+++ b/data/json/decision_points/nist_800_30/probability_scale_in_5_weighted_levels_ascending_1_0_0.json
@@ -1,0 +1,35 @@
+{
+  "namespace": "nist#800-30",
+  "key": "P_5X",
+  "version": "1.0.0",
+  "name": "Probability Scale in 5 weighted levels, ascending",
+  "definition": "A probability scale with finer resolution at both extremes, based on NIST SP 800-30 Rev. 1 Appendix G",
+  "schemaVersion": "2.0.0",
+  "values": [
+    {
+      "key": "VL",
+      "name": "Very Low",
+      "definition": "0% <= Probability < 5%. Highly unlikely."
+    },
+    {
+      "key": "L",
+      "name": "Low",
+      "definition": "5% <= Probability < 21%. Unlikely."
+    },
+    {
+      "key": "M",
+      "name": "Moderate",
+      "definition": "21% <= Probability < 80%. Somewhat likely."
+    },
+    {
+      "key": "H",
+      "name": "High",
+      "definition": "80% <= Probability < 96%. Highly likely."
+    },
+    {
+      "key": "VH",
+      "name": "Very High",
+      "definition": "96% <= Probability <= 100%. Almost certain."
+    }
+  ]
+}

--- a/data/json/ssvc_object_registry.json
+++ b/data/json/ssvc_object_registry.json
@@ -289,76 +289,6 @@
                 }
               }
             },
-            "P_5X": {
-              "key": "P_5X",
-              "versions": {
-                "1.0.0": {
-                  "version": "1.0.0",
-                  "obj": {
-                    "namespace": "basic",
-                    "key": "P_5X",
-                    "version": "1.0.0",
-                    "name": "Probability Scale in 5 weighted levels, ascending",
-                    "definition": "A probability scale with finer resolution at both extremes, based on NIST SP 800-30 Rev. 1 Appendix G",
-                    "schemaVersion": "2.0.0",
-                    "values": [
-                      {
-                        "key": "VL",
-                        "name": "Very Low",
-                        "definition": "0% <= Probability < 5%. Highly unlikely."
-                      },
-                      {
-                        "key": "L",
-                        "name": "Low",
-                        "definition": "5% <= Probability < 21%. Unlikely."
-                      },
-                      {
-                        "key": "M",
-                        "name": "Moderate",
-                        "definition": "21% <= Probability < 80%. Somewhat likely."
-                      },
-                      {
-                        "key": "H",
-                        "name": "High",
-                        "definition": "80% <= Probability < 96%. Highly likely."
-                      },
-                      {
-                        "key": "VH",
-                        "name": "Very High",
-                        "definition": "96% <= Probability <= 100%. Almost certain."
-                      }
-                    ]
-                  },
-                  "values": {
-                    "VL": {
-                      "key": "VL",
-                      "name": "Very Low",
-                      "definition": "0% <= Probability < 5%. Highly unlikely."
-                    },
-                    "L": {
-                      "key": "L",
-                      "name": "Low",
-                      "definition": "5% <= Probability < 21%. Unlikely."
-                    },
-                    "M": {
-                      "key": "M",
-                      "name": "Moderate",
-                      "definition": "21% <= Probability < 80%. Somewhat likely."
-                    },
-                    "H": {
-                      "key": "H",
-                      "name": "High",
-                      "definition": "80% <= Probability < 96%. Highly likely."
-                    },
-                    "VH": {
-                      "key": "VH",
-                      "name": "Very High",
-                      "definition": "96% <= Probability <= 100%. Almost certain."
-                    }
-                  }
-                }
-              }
-            },
             "P_2A": {
               "key": "P_2A",
               "versions": {
@@ -5979,6 +5909,81 @@
                       "key": "X",
                       "name": "Not Defined",
                       "definition": "This metric value is not defined. See CVSS documentation for details."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nist#800-30": {
+          "namespace": "nist#800-30",
+          "keys": {
+            "P_5X": {
+              "key": "P_5X",
+              "versions": {
+                "1.0.0": {
+                  "version": "1.0.0",
+                  "obj": {
+                    "namespace": "nist#800-30",
+                    "key": "P_5X",
+                    "version": "1.0.0",
+                    "name": "Probability Scale in 5 weighted levels, ascending",
+                    "definition": "A probability scale with finer resolution at both extremes, based on NIST SP 800-30 Rev. 1 Appendix G",
+                    "schemaVersion": "2.0.0",
+                    "values": [
+                      {
+                        "key": "VL",
+                        "name": "Very Low",
+                        "definition": "0% <= Probability < 5%. Highly unlikely."
+                      },
+                      {
+                        "key": "L",
+                        "name": "Low",
+                        "definition": "5% <= Probability < 21%. Unlikely."
+                      },
+                      {
+                        "key": "M",
+                        "name": "Moderate",
+                        "definition": "21% <= Probability < 80%. Somewhat likely."
+                      },
+                      {
+                        "key": "H",
+                        "name": "High",
+                        "definition": "80% <= Probability < 96%. Highly likely."
+                      },
+                      {
+                        "key": "VH",
+                        "name": "Very High",
+                        "definition": "96% <= Probability <= 100%. Almost certain."
+                      }
+                    ]
+                  },
+                  "values": {
+                    "VL": {
+                      "key": "VL",
+                      "name": "Very Low",
+                      "definition": "0% <= Probability < 5%. Highly unlikely."
+                    },
+                    "L": {
+                      "key": "L",
+                      "name": "Low",
+                      "definition": "5% <= Probability < 21%. Unlikely."
+                    },
+                    "M": {
+                      "key": "M",
+                      "name": "Moderate",
+                      "definition": "21% <= Probability < 80%. Somewhat likely."
+                    },
+                    "H": {
+                      "key": "H",
+                      "name": "High",
+                      "definition": "80% <= Probability < 96%. Highly likely."
+                    },
+                    "VH": {
+                      "key": "VH",
+                      "name": "Very High",
+                      "definition": "96% <= Probability <= 100%. Almost certain."
                     }
                   }
                 }

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -178,11 +178,16 @@ we expect that this will rarely lead to conflicts in practice.
       notation of a domain under their control to ensure uniqueness.
     - After the reverse domain name, a fragment separated by `#` must follow.
     - The construct of reverse domain name followed by `#` and a fragment is called `x-name`.
+    - For any domain using other characters, DNS Punycode must be used
     - Aside from the required `x_` prefix and the fragment separator `#`, unregistered
       namespaces must contain only alphanumeric characters, dots (`.`), and dashes (`-`).
 
-- For any domain using other characters, DNS Punycode must be used
+!!! note "Fragment Usage is Required in Unregistered Namespaces"
 
+    In unregistered namespaces, the fragment is _required_. This is different from
+    registered namespaces, where the fragment is _optional_.
+
+    
 !!! warning "Namespace Conflicts"
 
     Conflicts are possible in the `x_` prefix space - especially as the control over a
@@ -191,7 +196,8 @@ we expect that this will rarely lead to conflicts in practice.
     `x_example.test#test`, and there are no guarantees of global uniqueness for the
     decision points in the `x_example.test#test` namespace.
 
- !!! info "Documentation and Test Namespaces"
+
+!!! info "Documentation and Test Namespaces"
 
     Any namespace starting with `x_example` can be used in documentation or as examples,
     where a unregistered namespace is needed.
@@ -200,7 +206,7 @@ we expect that this will rarely lead to conflicts in practice.
     The namespace `x_example.test#documentation` is recommended for use in documentation
     or as examples.
 
- !!! tip "Test Namespace"
+!!! tip "Test Namespace"
 
     The `x_example.test#test` namespace is commonly used for testing purposes and is not
     intended for production use. It is used to test the SSVC framework and its components,
@@ -214,7 +220,8 @@ Extensions are optional and may be used to refine or clarify existing decision p
 Extensions allow SSVC users to create decision points that are specific to their
 constituencies or to provide translations of existing decision points.
 
-!!! info "Namespace Extension Requirements"
+
+!!! info "Namespace Extension Semantic Requirements"
 
     Extensions must follow the following requirements:
     
@@ -225,22 +232,28 @@ constituencies or to provide translations of existing decision points.
     - Extensions may reduce the set of values for a decision point in the parent
       namespace, but must not add new values.
 
+    See also the "Namespace Extension Structural Requirements" below.
+
+!!! question "Why are the Namespace Extension Semantic Requirements important?"
+
+    The way extensions are built enables tools to process the decision points even if
+    they do not know the defined extension. As long as the tool knows the base
+    namespace, it can process the decision point.
+
 !!! question "What if I want to create a new decision point?"
 
-    If you want to create a new decision point, please use a private/experimental namespace
+    If you want to create a new decision point, please use an unregistered namespace
     as described above instead of an extension.
     Extensions are not intended to be used to create new decision points.
 
-!!! question "Why is that important?"
-
-    The way extensions are build enables tools to process the decision points even if
-    they do not know the defined extension. As long as the tool knows the base
-    namespace, it can process the decision point.
 
 #### Namespace Extension Structure
 
 The first extension segment is reserved for an optional BCP-47 language tag, which may be left empty.
-When empty, the default language (`en-US`) is implied.
+
+!!! info "Default language is `en-US`"
+
+    If the first extension segment is left empty, the default language (`en-US`) is implied.
 
 Subsequent extension segments must either
 
@@ -266,7 +279,7 @@ The following diagram illustrates the structure of namespace extensions:
 
 ```mermaid
 ---
-title: Namespace Extensions
+title: Namespace Extension Structure
 ---
 flowchart LR
 
@@ -279,12 +292,22 @@ subgraph exts[Extensions]
         lang ~~~|OR| empty_lang
     end
     subgraph ext[Subsequent Extension Segments]
-        direction LR
-        e_lang[Language Tag]
-        dot[.]
-        reverse_ns_ext[Reverse Domain Name Notation]
-        fragment[#Fragment]
-        subgraph translation[Translation]
+        direction TB
+        
+        subgraph lang_seg[Language Only Segment]
+            e_lang[Language Tag]
+        end
+        
+        subgraph e_dot[Extension Segment]
+            direction LR
+            dot[.]
+            reverse_ns_ext[Reverse Domain Name Notation]
+            fragment[#Fragment]
+    
+            dot --> reverse_ns_ext --> fragment
+        end
+        
+        subgraph translation[Translation Segment]
             direction LR
             t_dot[.]
             t_reverse_ns_ext[Reverse Domain Name Notation]
@@ -292,9 +315,11 @@ subgraph exts[Extensions]
             t_dollar[$]
             t_lang[Language Tag]
             
-            t_dot --> t_reverse_ns_ext --> t_fragment --> t_dollar --> t_lang
+            t_dot --> t_reverse_ns_ext -.-> t_fragment -.-> t_dollar --> t_lang
+            t_reverse_ns_ext --> t_dollar
         end
-        lang ~~~|OR| dot --> reverse_ns_ext --> fragment ~~~|OR| translation
+        
+        lang_seg ~~~|OR| e_dot ~~~|OR| translation
     end
     first -->|/| ext
     ext -->|/| ext
@@ -305,7 +330,7 @@ base_ns -->|/| first
 
 ```
 
-!!! info "Namespace Extension Requirements"
+!!! info "Namespace Extension Structural Requirements"
 
     Extensions must follow the following structure:
   
@@ -322,17 +347,15 @@ base_ns -->|/| first
     The structure of the namespace string is intended to show inheritance for
     variations on SSVC objects. 
 
+
 !!! tip "Extension Order Matters"
 
-    Extension order matters. `ssvc/de-DE/.example.organization#ref-arch-1`
-    denotes that (a) an official German (Germany) translation of the SSVC decision points
-    is available, and (b) that this translation has been extended with an extension
-    by `organization.example` to fit their specific needs for `ref-arch-1`.
-
-    On the other hand, `ssvc//.example.organization#ref-arch-1/de-DE`
-    denotes that (a) the `.example.organization#ref-arch-1` extension is
-    available in the default language (`en-US`), and (b) that this extension has
-    been translated into German (Germany).
+    Extension order matters. 
+    
+    | Example | Meaning |
+    |---------|---------|
+    | `ssvc/de-DE/.example.organization#ref-arch-1` | Denotes (a) an official German (Germany) translation of the SSVC decision points is available, and (b) that this translation has been extended with an extension by `organization.example` to fit their specific needs for `ref-arch-1`.|
+    | `ssvc//.example.organization#ref-arch-1/de-DE` | Denotes that (a) the `.example.organization#ref-arch-1` extension is available in the default language (`en-US`), and (b) that this extension has been translated into German (Germany). |
 
 !!! example "Use of fragment identifiers and language tags"
 

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -57,6 +57,24 @@ subgraph base_ns[Base Namespace]
 end
 ```
 
+!!! warning "Reserved Namespace Strings"
+    
+    The SSVC project has _reserved_ the following namespace strings:
+
+    - `example` and `x_example`are _reserved_ for use in documentation or as 
+    examples where a registered namespace is needed.
+    No production use of the `example` or `x_example` namespace is intended.
+
+    - `test` and `x_test` are _reserved_ for use as a registered
+    namespace for use in testing of current or new SSVC related code.
+    No production use of the `test` namespace is intended.
+
+    - `invalid` and `x_invalid` are _reserved_ and must not be used as
+    registered or unregistered namespaces, respectively. Attempting to create an
+    object using either of these strings will result in an error in the Python
+    implementation of SSVC.
+
+
 !!! info inline end "Current Registered Namespaces"
 
     The SSVC project currently has a set of registered namespaces that are
@@ -71,12 +89,6 @@ end
         print(f"- {ns.value}")
     ```
 
-!!! warning "Reserved Namespace Strings"
-
-    The strings `invalid` and `x_invalid` are reserved and must not be used as
-    registered or unregistered namespaces, respectively. Attempting to create an
-    object using either of these strings will result in an error in the Python
-    implementation of SSVC.
 
 
 #### Registered Namespace

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -62,7 +62,7 @@ end
     The SSVC project has _reserved_ the following namespace strings:
 
     - `example` and `x_example`are _reserved_ for use in documentation or as 
-    examples where a registered namespace is needed.
+    examples where a registered or unregistered namespace is needed, respectively.
     No production use of the `example` or `x_example` namespace is intended.
 
     - `test` and `x_test` are _reserved_ for use in testing of current 

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -39,7 +39,7 @@ title: Base Namespace Structure
 flowchart LR
     
 subgraph base_ns[Base Namespace]
-    direction LR
+    direction TB
     subgraph unregistered[Unregistered Namespace]
         direction LR
         xpfx[x_]
@@ -50,6 +50,8 @@ subgraph base_ns[Base Namespace]
     subgraph registered[Registered Namespace]
         direction LR
         base_registered[Registered Base Namespace]
+        base_fragment[Fragment]
+        base_registered --> base_fragment
     end
     registered ~~~|OR| unregistered
 end
@@ -68,6 +70,14 @@ end
     for ns in NameSpace:
         print(f"- {ns.value}")
     ```
+
+!!! warning "Reserved Namespace Strings"
+
+    The strings `invalid` and `x_invalid` are reserved and must not be used as
+    registered or unregistered namespaces, respectively. Attempting to create an
+    object using either of these strings will result in an error in the Python
+    implementation of SSVC.
+
 
 #### Registered Namespace
 

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -136,10 +136,24 @@ Registered namespaces are intended to be used as follows:
     Suggestions for changes to the CVSS specifications should be directed to the
     [FIRST CVSS Special Interest Group](https://www.first.org/cvss/) (SIG).
 
-!!! example "Potential Standards-based namespaces"
+!!! note "Use of (Optional) Fragments in Registered Namespaces"
+
+    The optional fragment string following the `#` character in a registered 
+    namespace is used to indicate a grouping or subset of decision points within
+    the same namespace.
+    This allows us to organize decision points that are related or share a common
+    context within the same namespace.
+    
+!!! example "Fragment Usage in Registered Namespaces"
+    
+    We use the `nist` namespace for decision points based on NIST standards, and
+    fragments to differentiate between decision points based on different NIST publications,
+    e.g., `nist#800-30` for decision points based on NIST Special Publication 800-30.
 
     We may in the future add namespaces when needed to reflect different standards 
-    bodies like `nist`, `iso-iec`, `ietf`, `oasis`, etc. 
+    bodies like `iso-iec`, `ietf`, `oasis`, etc. We would expect to use fragments
+    in a similar way to differentiate between different standards or publications
+    from the same standards body.
 
 !!! question "How do I request a new registered namespace?"
 

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -350,7 +350,7 @@ base_ns -->|/| first
 
 !!! tip "Extension Order Matters"
 
-    Extension order matters. 
+    SSVC namespace extension order carries semantic meaning. 
     
     | Example | Meaning |
     |---------|---------|
@@ -429,7 +429,7 @@ and the ABNF specification in
 
 - Namespaces must be between 3 and 1000 characters long.
 
-(The ABNF is used to generated the regular expressions in
+(The ABNF is used to generate the regular expressions in
 `src/ssvc/utils/patterns.py`, see the comment in the source code there.)
 
 ## The `ssvc.namespaces` module

--- a/docs/reference/code/namespaces.md
+++ b/docs/reference/code/namespaces.md
@@ -51,7 +51,7 @@ subgraph base_ns[Base Namespace]
         direction LR
         base_registered[Registered Base Namespace]
         base_fragment[Fragment]
-        base_registered --> base_fragment
+        base_registered -.->|optional| base_fragment
     end
     registered ~~~|OR| unregistered
 end
@@ -65,8 +65,8 @@ end
     examples where a registered namespace is needed.
     No production use of the `example` or `x_example` namespace is intended.
 
-    - `test` and `x_test` are _reserved_ for use as a registered
-    namespace for use in testing of current or new SSVC related code.
+    - `test` and `x_test` are _reserved_ for use in testing of current 
+    or new SSVC related code.
     No production use of the `test` namespace is intended.
 
     - `invalid` and `x_invalid` are _reserved_ and must not be used as
@@ -311,11 +311,11 @@ subgraph exts[Extensions]
             direction LR
             t_dot[.]
             t_reverse_ns_ext[Reverse Domain Name Notation]
-            t_fragment[#Optional Fragment]
+            t_fragment[#Fragment]
             t_dollar[$]
             t_lang[Language Tag]
             
-            t_dot --> t_reverse_ns_ext -.-> t_fragment -.-> t_dollar --> t_lang
+            t_dot --> t_reverse_ns_ext -.->|optional| t_fragment -.-> t_dollar --> t_lang
             t_reverse_ns_ext --> t_dollar
         end
         

--- a/src/ssvc/decision_points/nist/__init__.py
+++ b/src/ssvc/decision_points/nist/__init__.py
@@ -17,13 +17,8 @@
 #  subject to its own license.
 #  DM24-0278
 
-"""Provides basic probability bin decision points."""
+"""Provides decision points based on NIST standards"""
 
-from .cis_wep import LATEST as CIS_WEP
-from .five_equal import LATEST as FIVE_EQUAL
-from .five_weighted import LATEST as FIVE_WEIGHTED
-from .two_equal import LATEST as TWO_EQUAL
+from .sp800_30_r1_g import LATEST as PROB_W5_SP800_30_R1_G
 
-DECISION_POINTS = {
-    dp.id: dp for dp in (TWO_EQUAL, FIVE_EQUAL, FIVE_WEIGHTED, CIS_WEP)
-}
+DECISION_POINTS = {dp.id: dp for dp in (PROB_W5_SP800_30_R1_G,)}

--- a/src/ssvc/decision_points/nist/base.py
+++ b/src/ssvc/decision_points/nist/base.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+"""
+Provides base classes for NIST-based decision points.
+"""
 #  Copyright (c) 2025 Carnegie Mellon University.
 #  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE
 #  ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
@@ -16,14 +20,13 @@
 #  This Software includes and/or makes use of Third-Party Software each
 #  subject to its own license.
 #  DM24-0278
+from pydantic import BaseModel
 
-"""Provides basic probability bin decision points."""
+from ssvc.decision_points.base import DecisionPoint
+from ssvc.namespaces import NameSpace
 
-from .cis_wep import LATEST as CIS_WEP
-from .five_equal import LATEST as FIVE_EQUAL
-from .five_weighted import LATEST as FIVE_WEIGHTED
-from .two_equal import LATEST as TWO_EQUAL
 
-DECISION_POINTS = {
-    dp.id: dp for dp in (TWO_EQUAL, FIVE_EQUAL, FIVE_WEIGHTED, CIS_WEP)
-}
+class NISTDecisionPoint(DecisionPoint, BaseModel):
+    """Base class for NIST-based decision points."""
+
+    namespace: str = NameSpace.NIST

--- a/src/ssvc/decision_points/nist/sp800_30_r1_g.py
+++ b/src/ssvc/decision_points/nist/sp800_30_r1_g.py
@@ -21,8 +21,9 @@ Provides a 5-level ascending probability scale decision point for SSVC
 #  subject to its own license.
 #  DM24-0278
 from ssvc.decision_points.base import DecisionPointValue
-from ssvc.decision_points.basic.base import BasicDecisionPoint
 from ssvc.decision_points.helpers import print_versions_and_diffs
+from ssvc.decision_points.nist.base import NISTDecisionPoint
+from ssvc.namespaces import FRAG_SEP, NameSpace
 
 # These ranges are based on NIST SP 800-30 Rev. 1 Appendix G
 
@@ -53,7 +54,8 @@ VERY_LOW = DecisionPointValue(
 )
 
 
-P5X = BasicDecisionPoint(
+P5X = NISTDecisionPoint(
+    namespace=FRAG_SEP.join((NameSpace.NIST, "800-30")),
     key="P_5X",
     version="1.0.0",
     name="Probability Scale in 5 weighted levels, ascending",

--- a/src/ssvc/namespaces.py
+++ b/src/ssvc/namespaces.py
@@ -23,7 +23,7 @@ for SSVC and provides a method to validate namespace values.
 #  subject to its own license.
 #  DM24-0278
 
-from enum import StrEnum, auto
+from enum import StrEnum
 
 from ssvc.utils.defaults import MAX_NS_LENGTH, MIN_NS_LENGTH, X_PFX
 from ssvc.utils.patterns import NS_PATTERN
@@ -62,12 +62,13 @@ class NameSpace(StrEnum):
 
     # auto() is used to automatically assign values to the members.
     # when used in a StrEnum, auto() assigns the lowercase name of the member as the value
-    SSVC = auto()
-    CVSS = auto()
-    CISA = auto()
-    BASIC = auto()
-    EXAMPLE = auto()
-    TEST = auto()
+    SSVC = "ssvc"
+    CVSS = "cvss"
+    CISA = "cisa"
+    BASIC = "basic"
+    EXAMPLE = "example"
+    TEST = "test"
+    NIST = "nist"
 
     @classmethod
     def validate(cls, value: str) -> str:

--- a/src/ssvc/namespaces.py
+++ b/src/ssvc/namespaces.py
@@ -28,6 +28,14 @@ from enum import StrEnum, auto
 from ssvc.utils.defaults import MAX_NS_LENGTH, MIN_NS_LENGTH, X_PFX
 from ssvc.utils.patterns import NS_PATTERN
 
+EXT_SEP = "/"
+FRAG_SEP = "#"
+
+# The following namespace strings are RESERVED and cannot be used
+# as the base of a namespace (i.e., before any fragment or extension),
+# even if they otherwise meet the pattern requirements.
+RESERVED_NS = ("invalid", "x_invalid")
+
 
 class NameSpace(StrEnum):
     f"""Define the official namespaces for SSVC.
@@ -79,20 +87,22 @@ class NameSpace(StrEnum):
         """
         valid = NS_PATTERN.match(value)
 
-        ext_sep = "/"
-        frag_sep = "#"
-
         if valid:
             # pattern matches, so we can proceed with further checks
             # partition always returns three parts: the part before the separator, the separator itself, and the part after the separator
-            (base_ns, _, extension) = value.partition(ext_sep)
+            (base_ns, _, extension) = value.partition(EXT_SEP)
             # and we don't care about the extension beyond the pattern match above
             # so base_ns is either the full value or the part before the first slash
 
             # but base_ns might have a fragment
             # so we need to split that off if present
+            # because partition always returns three parts, we can ignore the second and third parts here
             if "#" in base_ns:
-                (base_ns, _, fragment) = base_ns.partition(frag_sep)
+                (base_ns, _, _) = base_ns.partition(FRAG_SEP)
+
+            # reject reserved namespaces
+            if base_ns in RESERVED_NS:
+                raise ValueError(f"Invalid namespace: '{value}' is reserved.")
 
             if base_ns in cls.__members__.values():
                 # base_ns is a registered namespaces

--- a/src/test/test_namespaces.py
+++ b/src/test/test_namespaces.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from ssvc.namespaces import NameSpace
+from ssvc.namespaces import NameSpace, RESERVED_NS
 from ssvc.utils.patterns import NS_PATTERN
 
 
@@ -78,6 +78,10 @@ class MyTestCase(unittest.TestCase):
             self.assertTrue(NameSpace.validate(ns.value))
 
         for ns in ["foo", "bar", "baz", "quux"]:
+            with self.assertRaises(ValueError):
+                NameSpace.validate(ns)
+
+        for ns in RESERVED_NS:
             with self.assertRaises(ValueError):
                 NameSpace.validate(ns)
 


### PR DESCRIPTION
This PR:

- resolves #907 
- resolves #908
- might address #909 but there is not enough detail in that issue to tell whether it does or not
- Explicitly calls out _RESERVED_ namespace strings:
    - `invalid` and `x_invalid` are blocked from use
    - `example` and `x_example` are reserved for examples and documentation
    - `test` and `x_test` are reserved for tests
- adds a `nist` namespace
- refactors one of the probability-based decision points based on NIST 800-30 into the `nist` namespace
    - this incidentally resolved a situation in which two identically named decision points were clobbering each other when we generated the `.json` files, hence what appears to be an unrelated change to data/json/decision_points/basic/probability_scale_in_5_weighted_levels_ascending_1_0_0.json
- revises the `namespaces.md` documentation diagrams for clarity 

## Copilot Summary

This pull request refactors the probability scale decision point definitions and updates the documentation for namespace structure and extension usage. The main changes are the migration of the NIST-based probability scale to its own namespace, a redesign of the "basic" weighted probability scale, and comprehensive improvements to the documentation on namespace conventions and extensions.

**Decision Point Refactoring:**

* Migrated the NIST SP 800-30 probability scale (`P_5X`) from the `basic` namespace to a new `nist#800-30` namespace, restoring its original value definitions and associated registry entries. [[1]](diffhunk://#diff-8c9a7313f0be9e0bdf09ad01f0a8b3d6350edad5eadff0abc1521bd9afe2388eR1-R35) [[2]](diffhunk://#diff-dfa090915974450f002f695e3f15f988b5f70e69781f4436a3b9de083a8d897dR5919-R5993)
* Redesigned the `basic` probability scale (`P_5W`) to use ascending probability ranges with higher resolution as probability increases, replacing the previous NIST-based value definitions.
* Updated the SSVC object registry to remove the old `basic.P_5X` entry and add the new `nist#800-30.P_5X` entry. [[1]](diffhunk://#diff-dfa090915974450f002f695e3f15f988b5f70e69781f4436a3b9de083a8d897dL292-L361) [[2]](diffhunk://#diff-dfa090915974450f002f695e3f15f988b5f70e69781f4436a3b9de083a8d897dR5919-R5993)
* Updated the Python module `src/ssvc/decision_points/basic/probability/__init__.py` to remove the NIST probability scale from the basic namespace and ensure only the correct decision points are registered.

**Documentation Improvements (Namespace and Extension Structure):**

* Expanded documentation in `docs/reference/code/namespaces.md` to clarify reserved namespace strings, the use and requirements of fragments in registered and unregistered namespaces, and the semantic and structural requirements for namespace extensions. This includes new diagrams, notes, and examples for better understanding. [[1]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL42-R42) [[2]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efR53-R77) [[3]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL117-R156) [[4]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efR181-R189) [[5]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efR199) [[6]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL181-R224) [[7]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efR235-R256) [[8]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL233-R282) [[9]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL246-R322) [[10]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL272-R333) [[11]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efR350-R358) [[12]](diffhunk://#diff-dca4a22bc57327623b000b9c60802e06d9864a3dcbf75d66249c4996dac905efL373-R432)

These changes improve the clarity and maintainability of the decision point definitions and provide more robust guidance for namespace usage and extension in SSVC.