### PR TITLE
Change heading bar height to not be too small when scrolling

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -18,7 +18,7 @@
 }
 
 .md-header__inner {
-	height: 18px;
+	height: 50px;
 	padding-top: 1rem;
 	margin-bottom: 10px;
 }


### PR DESCRIPTION
Resolves #825 

Before scrolling: 
<img width="1258" height="323" alt="image" src="https://github.com/user-attachments/assets/bb4c338c-c62d-4f5e-abb1-9655280aa389" />

After scrolling, everything still fits in the red space:
<img width="1262" height="223" alt="image" src="https://github.com/user-attachments/assets/16ec6f2f-1c57-4f4e-8166-31d94b86dbd1" />
