### PR TITLE
Updated files to send to pypi project format with examples

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,20 +1,80 @@
-# Code
+CERTCC SSVC
+===========
 
-This directory holds helper scripts that can make managing or using SSVC easier.
+This is the official Python package for the CERT/CC Stakeholder-Specific Vulnerability Categorization (SSVC) project.
 
-## csv-to-latex
+Installation
+------------
+You can install the latest release from PyPI:
 
-This python script takes a CSV of the format in the `../data` directory and gets you (most of the way) to a pretty decision tree visualization. It creates a LaTeX file that can create a PDF (and from there, a PNG or whatever you want).
+    pip install certcc-ssvc
 
-`python SSVC_csv-to-latex.py --help` works and should explain all your options.
-When the script finishes, it will also print a message with instructions for creating the PDF or PNG from the tex. A potential future improvement is to call `latexmk` directly from the python script.
+Demo to explore SSVC decision making
+-----
+After installation, import the package and explore the examples:
 
-Example usage:
+    import ssvc
 
-```
- python SSVC_csv-to-latex.py --input=../data/ssvc_2_deployer_simplified.csv --output=tmp.tex --delim="," --columns="0,2,1" --label="3" --header-row --priorities="defer, scheduled, out-of-cycle, immediate"
-```
+    # Example decision point usage. A Weather Forecast and Humidity Value decision point
+    from ssvc.decision_points.example import weather
+    print(weather.LATEST.model_dump_json(indent=2))
+    from ssvc.decision_points.example import humidity
+    print(humidity.LATEST.model_dump_json(indent=2))
 
-Dependencies: LaTeX.
-To install latex, see <https://www.latex-project.org/get/>
-`latexmk` is a helper script that is not included in all distributions by default; if you need it, see <https://ctan.org/pkg/latexmk/?lang=en>
+
+    # Example decision table usage
+    from ssvc.decision_tables.example import to_play
+    print(to_play.LATEST.model_dump_json(indent=2))
+
+Explanation
+------
+
+This demo is a simple decision tree that provides an Outcome based on two conditions: the weather forecast and the humidity level.
+
+Imagine the decision tree as a series of questions. To find the outcome (the YesNo column), you start at the first question (Decision Point), which is the root node of the tree: What is the Weather Forecast?
+
+* Step 1: Look at the Weather Forecast column (e.g., rain, overcast, sunny).
+* Step 2: Look at the Humidity Value above 40% column (e.g., high, low).
+* Step 3: Based on the combination of these two conditions, the YesNo column will give you the Decision as "Yes" to play and "No" to not to play.
+
+The YesNo column is the Outcome Decision Point, and the other two Decision Points are inputs that will be collected. 
+
+Usage
+---------
+
+For usage in vulnerability management scenarios consider the following popular SSVC decisions
+
+    import ssvc
+
+    # Example decision point usage. Exploitation as a Decision Point
+    from ssvc.decision_points.ssvc.exploitation import LATEST as Exploitation
+    print(Exploitation.model_dump_json(indent=2))
+    # Try a CVSS metic Attack Vector using SSVC 
+    from ssvc.decision_points.cvss.attack_vector import LATEST as AttackVector
+    print(AttackVector.model_dump_json(indent=2))
+    from ssvc.decision_points.cisa.in_kev import LATEST as InKEV
+    print(InKEV.model_dump_json(indent=2))
+
+    # Example decision table for a Supplier deciding Patch Development Priority
+    from ssvc.decision_tables.ssvc.supplier_dt import LATEST as SupplierDT
+    print(SupplierDT.model_dump_json(indent=2))
+
+    # Example decision table for a Deployer decision Patch Application Priority
+    from ssvc.decision_tables.ssvc.deployer_dt import LATEST as DeployerDT
+    print(DeployerDT.model_dump_json(indent=2))
+
+    # View CISA Decision Table as Coordinator for Vulnerability Management writ large
+    from ssvc.decision_tables.cisa.cisa_coordinate_dt import LATEST as CISACoordinate
+    print(CISACoordinate.model_dump_json(indent=2))
+
+
+Resources
+---------
+Source code and full documentation:
+https://github.com/CERTCC/SSVC
+
+SSVC Policy Explorer:
+https://certcc.github.io/SSVC/ssvc-explorer/
+
+SSVC Calculator:
+https://certcc.github.io/SSVC/ssvc-calc/

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -13,19 +13,17 @@ build-backend = "setuptools.build_meta"
 #build-backend = "pdm.backend"
 
 [project]
-name = "ssvc"
+name = "certcc-ssvc"
 authors = [
-    { name = "Allen D. Householder", email="adh@cert.org" },
-    { name = "Vijay Sarvepalli", email="vssarvepalli@cert.org"}
+    { name = "CERT/CC SSVC", email="cert+ssvc@cert.org"}
 ]
 description = "Tools for working with a Stakeholder Specific Vulnerability Categorization (SSVC)"
 readme = {file="README.md", content-type="text/markdown"}
 requires-python = ">=3.12"
 keywords =["ssvc","vulnerability management","vulnerability management"]
-license = {file="LICENSE.md"}
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Topic :: Security",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -71,7 +69,8 @@ exclude = ["test*"]  # exclude packages matching these glob patterns (empty by d
 [tool.setuptools_scm]
 version_file = "ssvc/_version.py"
 root = ".."
-relative_to = "pyproject.toml"
+local_scheme = "no-local-version"
+version_scheme = "no-guess-dev"
 
 
 #[tools.setuptools.dynamic]

--- a/src/ssvc/decision_points/example/humidity.py
+++ b/src/ssvc/decision_points/example/humidity.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""
+Provides example decision point for humidity values
+"""
+#  Copyright (c) 2024-2025 Carnegie Mellon University.
+#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE
+#  ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+#  CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND,
+#  EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT
+#  NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR
+#  MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE
+#  OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE
+#  ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM
+#  PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#  Licensed under a MIT (SEI)-style license, please see LICENSE or contact
+#  permission@sei.cmu.edu for full terms.
+#  [DISTRIBUTION STATEMENT A] This material has been approved for
+#  public release and unlimited distribution. Please see Copyright notice
+#  for non-US Government use and distribution.
+#  This Software includes and/or makes use of Third-Party Software each
+#  subject to its own license.
+#  DM24-0278
+
+from ssvc.decision_points.base import DecisionPointValue
+from ssvc.decision_points.helpers import print_versions_and_diffs
+from ssvc.decision_points.ssvc.base import SsvcDecisionPoint
+
+LOW = DecisionPointValue(
+    name="Low",
+    key="L",
+    definition="Humidity is low, below 40%."
+)
+
+HIGH = DecisionPointValue(
+    name="High",
+    key="H",
+    definition="Humidity is high, above 40%"
+)
+HUMIDITY_1 = SsvcDecisionPoint(
+    name="Humidity Value above 40% ",
+    namespace="x_example.test#forecast",
+    definition="Humidity is the amount of water vapor in the air. Above 40% is High in this context.",
+    key="H",
+    version="1.0.0",
+    values=(
+        HIGH,
+        LOW
+    ),
+)
+
+VERSIONS = (HUMIDITY_1,)
+LATEST = VERSIONS[-1]
+
+
+def main():
+    print_versions_and_diffs(VERSIONS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ssvc/decision_points/example/weather.py
+++ b/src/ssvc/decision_points/example/weather.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""
+Provides example decision point for weather forecast
+"""
+#  Copyright (c) 2024-2025 Carnegie Mellon University.
+#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE
+#  ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+#  CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND,
+#  EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT
+#  NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR
+#  MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE
+#  OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE
+#  ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM
+#  PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#  Licensed under a MIT (SEI)-style license, please see LICENSE or contact
+#  permission@sei.cmu.edu for full terms.
+#  [DISTRIBUTION STATEMENT A] This material has been approved for
+#  public release and unlimited distribution. Please see Copyright notice
+#  for non-US Government use and distribution.
+#  This Software includes and/or makes use of Third-Party Software each
+#  subject to its own license.
+#  DM24-0278
+
+from ssvc.decision_points.base import DecisionPointValue
+from ssvc.decision_points.helpers import print_versions_and_diffs
+from ssvc.decision_points.ssvc.base import SsvcDecisionPoint
+
+SUNNY = DecisionPointValue(
+    name="Sunny",
+    key="S",
+    definition="Weather is sunny."
+)
+
+OVERCAST = DecisionPointValue(
+    name="Overcast",
+    key="O",
+    definition="Weather is overcast."
+)
+
+RAIN = DecisionPointValue(
+    name="Rain",
+    key="R",
+    definition="Weather is rainy."
+)
+
+WEATHER_FORECAST_1 = SsvcDecisionPoint(
+    name="Weather Forecast",
+    namespace="x_example.test#forecast",
+    definition="Weather is the forecast that describes general weather patterns ",
+    key="W",
+    version="1.0.0",
+    values=(
+        RAIN,
+        OVERCAST,
+        SUNNY,
+    ),
+)
+
+VERSIONS = (WEATHER_FORECAST_1,)
+LATEST = VERSIONS[-1]
+
+
+def main():
+    print_versions_and_diffs(VERSIONS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ssvc/decision_tables/example/to_play.py
+++ b/src/ssvc/decision_tables/example/to_play.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""
+Models an example to play or not to play decision table for SSVC.
+"""
+#  Copyright (c) 2025 Carnegie Mellon University.
+#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE
+#  ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+#  CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND,
+#  EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT
+#  NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR
+#  MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE
+#  OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE
+#  ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM
+#  PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#  Licensed under a MIT (SEI)-style license, please see LICENSE or contact
+#  permission@sei.cmu.edu for full terms.
+#  [DISTRIBUTION STATEMENT A] This material has been approved for
+#  public release and unlimited distribution. Please see Copyright notice
+#  for non-US Government use and distribution.
+#  This Software includes and/or makes use of Third-Party Software each
+#  subject to its own license.
+#  DM24-0278
+
+from ssvc.decision_points.example.weather import LATEST as WEATHER
+from ssvc.decision_points.example.humidity import LATEST as HUMIDITY
+from ssvc.outcomes.basic.yn import LATEST as YESNO
+
+
+from ssvc.decision_tables.base import DecisionTable
+from ssvc.namespaces import NameSpace
+
+dp_dict = {
+    dp.id: dp for dp in [WEATHER, HUMIDITY, YESNO]
+}
+
+
+TOPLAY_1 = DecisionTable(
+    namespace="x_example.test#play",
+    key="TP",
+    version="1.0.0",
+    name="To Play",
+    definition="To play or not to play that is the question",
+    decision_points={
+        dp.id: dp for dp in [WEATHER, HUMIDITY, YESNO]
+    },
+    outcome=YESNO.id,
+    mapping=[
+    {
+      "x_example.test#forecast:W:1.0.0": "R",
+      "x_example.test#forecast:H:1.0.0": "H",
+      "basic:YN:1.0.0": "N"
+    },
+    {
+      "x_example.test#forecast:W:1.0.0": "O",
+      "x_example.test#forecast:H:1.0.0": "H",
+      "basic:YN:1.0.0": "N"
+    },
+    {
+      "x_example.test#forecast:W:1.0.0": "R",
+      "x_example.test#forecast:H:1.0.0": "L",
+      "basic:YN:1.0.0": "N"
+    },
+    {
+      "x_example.test#forecast:W:1.0.0": "S",
+      "x_example.test#forecast:H:1.0.0": "H",
+      "basic:YN:1.0.0": "N"
+    },
+    {
+      "x_example.test#forecast:W:1.0.0": "O",
+      "x_example.test#forecast:H:1.0.0": "L",
+      "basic:YN:1.0.0": "Y"
+    },
+    {
+      "x_example.test#forecast:W:1.0.0": "S",
+      "x_example.test#forecast:H:1.0.0": "L",
+      "basic:YN:1.0.0": "Y"
+    }
+    ],
+)
+
+VERSIONS = [
+    TOPLAY_1,
+]
+LATEST = TOPLAY_1
+
+
+def main():
+
+    print("## To Play Decision Table Object")
+    print()
+    print(TOPLAY_1.model_dump_json(indent=2))
+
+    print("## To Play Decision Table Longform DataFrame CSV")
+    print()
+    from ssvc.decision_tables.base import decision_table_to_longform_df
+
+    print(decision_table_to_longform_df(TOPLAY_1).to_csv(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This will be to help publish our SSVC project tin pypi as a project. 

1. The src/ssvc/ project currently has updated with some examples that walk through Decision Point and Decision Table creation with a fictitious WeatherForecast + Humidity (both decision points) will help decide whether to play or not to play (decision table)
2. The repository `pyproject.toml` is updated to remove deprecated `relative_to` and add `_scheme` flags complaint with pypi project. 
3. The name of the project is `certcc-ssvc` as somebody has already registered an alternate `ssvc` name. Pople will have to install it vase `pip install certcc-ssvc` 
4. When updating the respoitory we will put things in a `pypi` branch with git tag `date +%Y.%-m.%-d%H%M` format to auto-build version numbers that will be pushed to pypi project.
5. Currently no CI/CD is setup to take over the project and feed form GitHub ot PyPi (pending).


