### PR TITLE
Make value key its own column when rendering decision point examples

### DIFF
--- a/src/ssvc/doc_helpers.py
+++ b/src/ssvc/doc_helpers.py
@@ -25,7 +25,7 @@ created_at: 2/14/25 2:54 PM
 
 from ssvc.decision_points.ssvc.base import SsvcDecisionPoint
 
-MD_TABLE_ROW_TEMPLATE = "| {value.name} ({value.key}) | {value.definition} |"
+MD_TABLE_ROW_TEMPLATE = "| {value.name} | {value.key} | {value.definition} |"
 
 
 def markdown_table(dp: SsvcDecisionPoint, indent: int = 0) -> str:
@@ -43,8 +43,8 @@ def markdown_table(dp: SsvcDecisionPoint, indent: int = 0) -> str:
     _indent = " " * indent
     rows.append(f"{_indent}{dp.definition}")
     rows.append("")
-    rows.append(f"{_indent}| Value | Definition |")
-    rows.append(f"{_indent}|:-----|:-----------|")
+    rows.append(f"{_indent}| Value | Key | Definition |")
+    rows.append(f"{_indent}|:-----|:---|:-----------|")
 
     # add a row for each value
     for value in dp.values:

--- a/src/test/test_doc_helpers.py
+++ b/src/test/test_doc_helpers.py
@@ -50,10 +50,10 @@ class MyTestCase(unittest.TestCase):
         expected = (
             "test description\n"
             "\n"
-            "| Value | Definition |\n"
-            "|:-----|:-----------|\n"
-            "| A (A) | A Definition |\n"
-            "| B (B) | B Definition |"
+            "| Value | Key | Definition |\n"
+            "|:-----|:---|:-----------|\n"
+            "| A | A | A Definition |\n"
+            "| B | B | B Definition |"
         )
 
         self.assertEqual(result, expected)
@@ -63,10 +63,10 @@ class MyTestCase(unittest.TestCase):
         expected_indented = (
             "    test description\n"
             "\n"
-            "    | Value | Definition |\n"
-            "    |:-----|:-----------|\n"
-            "    | A (A) | A Definition |\n"
-            "    | B (B) | B Definition |"
+            "    | Value | Key | Definition |\n"
+            "    |:-----|:---|:-----------|\n"
+            "    | A | A | A Definition |\n"
+            "    | B | B | B Definition |"
         )
 
         self.assertEqual(indented, expected_indented)
@@ -76,9 +76,9 @@ class MyTestCase(unittest.TestCase):
         result = example_block(self.dp)
 
         self.assertIn("!!! note", result)
-        self.assertIn("\n    | Value | Definition |", result)
-        self.assertIn("\n    | A (A) | A Definition |", result)
-        self.assertIn("\n    | B (B) | B Definition |", result)
+        self.assertIn("\n    | Value | Key | Definition |", result)
+        self.assertIn("\n    | A | A | A Definition |", result)
+        self.assertIn("\n    | B | B | B Definition |", result)
         self.assertIn("\n    ??? example", result)
         self.assertIn("\n        ```json", result)
 


### PR DESCRIPTION
This PR modifies the behavior when we render decision points as markdown tables. Instead of having `Name (key)`, now it will render `Name` and `Key` into separate columns.

Before:
<img width="734" height="421" alt="Screenshot 2025-09-15 at 11 37 31 AM" src="https://github.com/user-attachments/assets/d96624cf-5ecb-447e-bdc5-aacabcfaa249" />

After:
<img width="763" height="420" alt="Screenshot 2025-09-15 at 11 38 04 AM" src="https://github.com/user-attachments/assets/69dea5da-94cc-43bf-950b-a5e7204dfda1" />

## Copilot Summary

This pull request updates the markdown table formatting in the `src/ssvc/doc_helpers.py` file to improve clarity and completeness. The changes modify both the table row template and the table header to include a separate column for the key of each value.

Markdown table formatting improvements:

* Changed the `MD_TABLE_ROW_TEMPLATE` to include a separate "Key" column, so each row now displays the value's name, key, and definition individually.
* Updated the markdown table header and alignment to add the "Key" column, ensuring the header matches the new row format.