### PR TITLE
Clean up examples

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ email-validator==2.2.0 \
 fastapi==0.116.1 \
     --hash=sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565 \
     --hash=sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143
-    # via ssvc
+    # via certcc-ssvc
 fastapi-cli==0.0.8 \
     --hash=sha256:0ea95d882c85b9219a75a65ab27e8da17dac02873e456850fa0a726e96e985eb \
     --hash=sha256:2360f2989b1ab4a3d7fc8b3a0b20e8288680d8af2e31de7c38309934d7f8a0ee
@@ -199,7 +199,7 @@ joblib==1.5.1 \
 jsonschema==4.25.1 \
     --hash=sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63 \
     --hash=sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85
-    # via ssvc
+    # via certcc-ssvc
 jsonschema-specifications==2025.4.1 \
     --hash=sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af \
     --hash=sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608
@@ -223,7 +223,7 @@ markdown==3.8.2 \
 markdown-exec==1.11.0 \
     --hash=sha256:0526957984980f55c02b425d32e8ac8bb21090c109c7012ff905d3ddcc468ceb \
     --hash=sha256:e0313a0dff715869a311d24853b3a7ecbbaa12e74eb0f3cf7d91401a7d8f0082
-    # via ssvc
+    # via certcc-ssvc
 markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
     --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
@@ -279,13 +279,13 @@ mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \
     --hash=sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e
     # via
+    #   certcc-ssvc
     #   mkdocs-autorefs
     #   mkdocs-bibtex
     #   mkdocs-include-markdown-plugin
     #   mkdocs-material
     #   mkdocs-table-reader-plugin
     #   mkdocstrings
-    #   ssvc
 mkdocs-autorefs==1.4.2 \
     --hash=sha256:83d6d777b66ec3c372a1aad4ae0cf77c243ba5bcda5bf0c6b8a2c5e7a3d89f13 \
     --hash=sha256:e2ebe1abd2b67d597ed19378c0fff84d73d1dbce411fce7a7cc6f161888b6749
@@ -295,7 +295,7 @@ mkdocs-autorefs==1.4.2 \
 mkdocs-bibtex==4.4.0 \
     --hash=sha256:32a1e0624ab0e0edc3539a90a5ffe0a2cb965f03ad5df8746a9fc9e049b6778b \
     --hash=sha256:fc0ce0f9641b63f900585a48cc09f5817345bbaba1435abf361e21fafe279723
-    # via ssvc
+    # via certcc-ssvc
 mkdocs-get-deps==0.2.0 \
     --hash=sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c \
     --hash=sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134
@@ -303,41 +303,41 @@ mkdocs-get-deps==0.2.0 \
 mkdocs-include-markdown-plugin==7.1.6 \
     --hash=sha256:7975a593514887c18ecb68e11e35c074c5499cfa3e51b18cd16323862e1f7345 \
     --hash=sha256:a0753cb82704c10a287f1e789fc9848f82b6beb8749814b24b03dd9f67816677
-    # via ssvc
+    # via certcc-ssvc
 mkdocs-material==9.6.18 \
     --hash=sha256:a2eb253bcc8b66f8c6eaf8379c10ed6e9644090c2e2e9d0971c7722dc7211c05 \
     --hash=sha256:dbc1e146a0ecce951a4d84f97b816a54936cdc9e1edd1667fc6868878ac06701
     # via
+    #   certcc-ssvc
     #   mkdocs-print-site-plugin
-    #   ssvc
 mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
     # via
+    #   certcc-ssvc
     #   mkdocs-material
-    #   ssvc
 mkdocs-print-site-plugin==2.8 \
     --hash=sha256:838bd0a9b7141c11c0f1fdaa51ffe70c35740bec1f07c0806f8018e92f93f9da \
     --hash=sha256:ab1c89cdb468352975e3bb3bb0ef25dcc2bb88931b03f173206dc95ab02f843f
-    # via ssvc
+    # via certcc-ssvc
 mkdocs-table-reader-plugin==3.1.0 \
     --hash=sha256:50a1302661c14d96b90ba0434ae96110441e0c653ce23559e3c6911fe79e7bd2 \
     --hash=sha256:eb15688ee8c0cd1a842f506f18973b87be22bd7baa5e2e551089de6b7f9ec25b
-    # via ssvc
+    # via certcc-ssvc
 mkdocstrings==0.30.0 \
     --hash=sha256:5d8019b9c31ddacd780b6784ffcdd6f21c408f34c0bd1103b5351d609d5b4444 \
     --hash=sha256:ae9e4a0d8c1789697ac776f2e034e2ddd71054ae1cf2c2bb1433ccfd07c226f2
     # via
+    #   certcc-ssvc
     #   mkdocstrings-python
-    #   ssvc
 mkdocstrings-python==1.17.0 \
     --hash=sha256:49903fa355dfecc5ad0b891e78ff5d25d30ffd00846952801bbe8331e123d4b0 \
     --hash=sha256:c6295962b60542a9c7468a3b515ce8524616ca9f8c1a38c790db4286340ba501
-    # via ssvc
+    # via certcc-ssvc
 networkx==3.4.2 \
     --hash=sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1 \
     --hash=sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f
-    # via ssvc
+    # via certcc-ssvc
 numpy==2.3.2 \
     --hash=sha256:07b62978075b67eee4065b166d000d457c82a1efe726cce608b9db9dd66a73a5 \
     --hash=sha256:087ffc25890d89a43536f75c5fe8770922008758e8eeeef61733957041ed2f9b \
@@ -476,8 +476,8 @@ pandas==2.3.2 \
     --hash=sha256:d2c3554bd31b731cd6490d94a28f3abb8dd770634a9e06eb6d2911b9827db370 \
     --hash=sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4
     # via
+    #   certcc-ssvc
     #   mkdocs-table-reader-plugin
-    #   ssvc
 pathspec==0.12.1 \
     --hash=sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08 \
     --hash=sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
@@ -498,11 +498,11 @@ pydantic==2.11.7 \
     --hash=sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db \
     --hash=sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b
     # via
+    #   certcc-ssvc
     #   fastapi
     #   fastapi-cloud-cli
     #   pydantic-extra-types
     #   pydantic-settings
-    #   ssvc
 pydantic-core==2.33.2 \
     --hash=sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56 \
     --hash=sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef \
@@ -823,7 +823,7 @@ scikit-learn==1.6.1 \
     --hash=sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348 \
     --hash=sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1 \
     --hash=sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97
-    # via ssvc
+    # via certcc-ssvc
 scipy==1.16.1 \
     --hash=sha256:0851f6a1e537fe9399f35986897e395a1aa61c574b178c0d456be5b1a0f5ca1f \
     --hash=sha256:15240c3aac087a522b4eaedb09f0ad061753c5eebf1ea430859e5bf8640d5919 \
@@ -872,12 +872,12 @@ scipy==1.16.1 \
     --hash=sha256:f965bbf3235b01c776115ab18f092a95aa74c271a52577bcb0563e85738fd618 \
     --hash=sha256:fedc2cbd1baed37474b1924c331b97bdff611d762c196fac1a9b71e67b813b1b
     # via
+    #   certcc-ssvc
     #   scikit-learn
-    #   ssvc
 semver==3.0.4 \
     --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746 \
     --hash=sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602
-    # via ssvc
+    # via certcc-ssvc
 sentry-sdk==2.35.0 \
     --hash=sha256:5ea58d352779ce45d17bc2fa71ec7185205295b83a9dbb5707273deb64720092 \
     --hash=sha256:6e0c29b9a5d34de8575ffb04d289a987ff3053cf2c98ede445bea995e3830263
@@ -913,7 +913,7 @@ tabulate==0.9.0 \
 thefuzz==0.22.1 \
     --hash=sha256:59729b33556850b90e1093c4cf9e618af6f2e4c985df193fdf3c5b5cf02ca481 \
     --hash=sha256:7138039a7ecf540da323792d8592ef9902b1d79eb78c147d4f20664de79f3680
-    # via ssvc
+    # via certcc-ssvc
 threadpoolctl==3.6.0 \
     --hash=sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb \
     --hash=sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e

--- a/src/ssvc/decision_points/example/humidity.py
+++ b/src/ssvc/decision_points/example/humidity.py
@@ -22,30 +22,22 @@ Provides example decision point for humidity values
 #  DM24-0278
 
 from ssvc.decision_points.base import DecisionPointValue
+from ssvc.decision_points.example.base import ExampleDecisionPoint
 from ssvc.decision_points.helpers import print_versions_and_diffs
-from ssvc.decision_points.ssvc.base import SsvcDecisionPoint
 
 LOW = DecisionPointValue(
-    name="Low",
-    key="L",
-    definition="Humidity is low, below 40%."
+    name="Low", key="L", definition="Humidity is low, below 40%."
 )
 
 HIGH = DecisionPointValue(
-    name="High",
-    key="H",
-    definition="Humidity is high, above 40%"
+    name="High", key="H", definition="Humidity is high, above 40%"
 )
-HUMIDITY_1 = SsvcDecisionPoint(
+HUMIDITY_1 = ExampleDecisionPoint(
     name="Humidity Value above 40% ",
-    namespace="x_example.test#forecast",
     definition="Humidity is the amount of water vapor in the air. Above 40% is High in this context.",
     key="H",
     version="1.0.0",
-    values=(
-        HIGH,
-        LOW
-    ),
+    values=(HIGH, LOW),
 )
 
 VERSIONS = (HUMIDITY_1,)

--- a/src/ssvc/decision_points/example/weather.py
+++ b/src/ssvc/decision_points/example/weather.py
@@ -22,30 +22,21 @@ Provides example decision point for weather forecast
 #  DM24-0278
 
 from ssvc.decision_points.base import DecisionPointValue
+from ssvc.decision_points.example.base import ExampleDecisionPoint
 from ssvc.decision_points.helpers import print_versions_and_diffs
-from ssvc.decision_points.ssvc.base import SsvcDecisionPoint
 
 SUNNY = DecisionPointValue(
-    name="Sunny",
-    key="S",
-    definition="Weather is sunny."
+    name="Sunny", key="S", definition="Weather is sunny."
 )
 
 OVERCAST = DecisionPointValue(
-    name="Overcast",
-    key="O",
-    definition="Weather is overcast."
+    name="Overcast", key="O", definition="Weather is overcast."
 )
 
-RAIN = DecisionPointValue(
-    name="Rain",
-    key="R",
-    definition="Weather is rainy."
-)
+RAIN = DecisionPointValue(name="Rain", key="R", definition="Weather is rainy.")
 
-WEATHER_FORECAST_1 = SsvcDecisionPoint(
+WEATHER_FORECAST_1 = ExampleDecisionPoint(
     name="Weather Forecast",
-    namespace="x_example.test#forecast",
     definition="Weather is the forecast that describes general weather patterns ",
     key="W",
     version="1.0.0",

--- a/src/ssvc/decision_tables/example/to_play.py
+++ b/src/ssvc/decision_tables/example/to_play.py
@@ -21,60 +21,52 @@ Models an example to play or not to play decision table for SSVC.
 #  subject to its own license.
 #  DM24-0278
 
-from ssvc.decision_points.example.weather import LATEST as WEATHER
 from ssvc.decision_points.example.humidity import LATEST as HUMIDITY
+from ssvc.decision_points.example.weather import LATEST as WEATHER
+from ssvc.decision_tables.example.base import ExampleDecisionTable
 from ssvc.outcomes.basic.yn import LATEST as YESNO
 
-
-from ssvc.decision_tables.base import DecisionTable
-from ssvc.namespaces import NameSpace
-
-dp_dict = {
-    dp.id: dp for dp in [WEATHER, HUMIDITY, YESNO]
-}
+dp_dict = {dp.id: dp for dp in [WEATHER, HUMIDITY, YESNO]}
 
 
-TOPLAY_1 = DecisionTable(
-    namespace="x_example.test#play",
+TOPLAY_1 = ExampleDecisionTable(
     key="TP",
     version="1.0.0",
     name="To Play",
     definition="To play or not to play that is the question",
-    decision_points={
-        dp.id: dp for dp in [WEATHER, HUMIDITY, YESNO]
-    },
+    decision_points={dp.id: dp for dp in [WEATHER, HUMIDITY, YESNO]},
     outcome=YESNO.id,
     mapping=[
-    {
-      "x_example.test#forecast:W:1.0.0": "R",
-      "x_example.test#forecast:H:1.0.0": "H",
-      "basic:YN:1.0.0": "N"
-    },
-    {
-      "x_example.test#forecast:W:1.0.0": "O",
-      "x_example.test#forecast:H:1.0.0": "H",
-      "basic:YN:1.0.0": "N"
-    },
-    {
-      "x_example.test#forecast:W:1.0.0": "R",
-      "x_example.test#forecast:H:1.0.0": "L",
-      "basic:YN:1.0.0": "N"
-    },
-    {
-      "x_example.test#forecast:W:1.0.0": "S",
-      "x_example.test#forecast:H:1.0.0": "H",
-      "basic:YN:1.0.0": "N"
-    },
-    {
-      "x_example.test#forecast:W:1.0.0": "O",
-      "x_example.test#forecast:H:1.0.0": "L",
-      "basic:YN:1.0.0": "Y"
-    },
-    {
-      "x_example.test#forecast:W:1.0.0": "S",
-      "x_example.test#forecast:H:1.0.0": "L",
-      "basic:YN:1.0.0": "Y"
-    }
+        {
+            "example:W:1.0.0": "R",
+            "example:H:1.0.0": "H",
+            "basic:YN:1.0.0": "N",
+        },
+        {
+            "example:W:1.0.0": "O",
+            "example:H:1.0.0": "H",
+            "basic:YN:1.0.0": "N",
+        },
+        {
+            "example:W:1.0.0": "R",
+            "example:H:1.0.0": "L",
+            "basic:YN:1.0.0": "N",
+        },
+        {
+            "example:W:1.0.0": "S",
+            "example:H:1.0.0": "H",
+            "basic:YN:1.0.0": "N",
+        },
+        {
+            "example:W:1.0.0": "O",
+            "example:H:1.0.0": "L",
+            "basic:YN:1.0.0": "Y",
+        },
+        {
+            "example:W:1.0.0": "S",
+            "example:H:1.0.0": "L",
+            "basic:YN:1.0.0": "Y",
+        },
     ],
 )
 


### PR DESCRIPTION
We can use the _registered_ `example` namespace for examples. It is already set up with base classes for both `ExampleDecisionPoint` and `ExampleDecisionTable` so that it also avoids registering the decision points and tables in the registry.

## Copilot Summary

This pull request refactors the example decision point and decision table implementations to use new base classes specific to examples, and updates the identifiers in the decision table mappings to match the new naming convention. The changes improve consistency and modularity in the example code.

**Refactoring to use example-specific base classes:**

* Replaced usage of `SsvcDecisionPoint` with `ExampleDecisionPoint` in `humidity.py` and `weather.py` to clarify the distinction between example and SSVC decision points. [[1]](diffhunk://#diff-93283ff588b4a2bf5cf7b9bf483309aeed899ad3e4c0f1dafcce1e954f2dac85R25-R40) [[2]](diffhunk://#diff-0cbd0f3c98933b1c6249532bdb2dd8c18dad0ebac4f6974a727df79d5b09fe25R25-L48)
* Updated `to_play.py` to use `ExampleDecisionTable` instead of the generic `DecisionTable`.

**Naming and import consistency:**

* Standardized the import order and removed unused imports in `to_play.py` for clarity and consistency.

**Identifier and mapping updates:**

* Changed decision point and outcome identifiers in the `mapping` section of `to_play.py` from the old `x_example.test#forecast` format to the new `example` namespace to match the updated decision point definitions.