### PR TITLE
Remove the word 'policy' from policy explorer

### DIFF
--- a/docs/ssvc-explorer/findex.html
+++ b/docs/ssvc-explorer/findex.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SSVC Policy Explorer</title>
+    <title>SSVC Explorer</title>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"
 	    integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2"
 	    crossorigin="anonymous">

--- a/docs/ssvc-explorer/index.md
+++ b/docs/ssvc-explorer/index.md
@@ -4,7 +4,7 @@ hide:
   - title
 ---
 
-# SSVC Policy Explorer
+# SSVC Explorer
 
 <style>
 .sembed {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,7 +143,7 @@ nav:
         - Policy Generator: 'reference/code/policy_generator.md'
         - Doctools: 'reference/code/doctools.md'
   - Calculator: 'ssvc-calc/index.md'
-  - Policy Explorer: 'ssvc-explorer/index.md'  
+  - Explorer: 'ssvc-explorer/index.md'  
   - About:
     - Intro: 'about/index.md'
     - Community Engagement: 'about/contributing.md'


### PR DESCRIPTION
@sei-vsarvepalli Should anything else be modified?
Resolves #995 
This pull request updates the branding of the SSVC Policy Explorer to simply "SSVC Explorer" throughout the documentation and navigation. The changes ensure consistency in naming across the site.

Branding and naming updates:

* Changed the page title in `findex.html` from "SSVC Policy Explorer" to "SSVC Explorer".
* Updated the main heading in `index.md` from "SSVC Policy Explorer" to "SSVC Explorer".
* Renamed the navigation entry in `mkdocs.yml` from "Policy Explorer" to "Explorer".