### PR TITLE
Extend methods to generate Selection Schema for CVE and other projects

### DIFF
--- a/src/ssvc/selection.py
+++ b/src/ssvc/selection.py
@@ -312,7 +312,51 @@ class SelectionList(_SchemaVersioned, _Timestamped, BaseModel):
         schema = strip_nullable_anyof(schema)
 
         return order_schema(schema)
+    def _post_process(self, data):
+        """
+        Ensures all Selection.values are lists and removes empty array elements.
+        """
+        def fix_selection(selection):
+            # Convert tuple to list and filter out empty items
+            values = selection.get("values", [])
+            # Ensure it's a list, filter out empty/falsy items
+            selection["values"] = [v for v in list(values) if v]
+            return selection
 
+        # If this is a dict with selections, process each selection
+        if isinstance(data, dict) and "selections" in data:
+            data["selections"] = [
+                fix_selection(sel) for sel in data["selections"] if sel
+            ]
+        # Remove empty array fields from the top level
+        keys_to_delete = [k for k, v in data.items() if isinstance(v, list) and not v]
+        for k in keys_to_delete:
+            del data[k]
+        return data
+
+    def model_dump(self, *args, **kwargs):
+        data = super().model_dump(*args, **kwargs)
+        return self._post_process(data)
+
+    def model_dump_json(self, *args, **kwargs):
+        # Dump to python dict first, post-process, then dump to JSON
+        import json
+        from datetime import timezone
+        model_dump_kwargs = kwargs.copy()
+        json_kwargs = {}
+        # List of json.dumps kwargs you want to support
+        json_kwarg_names = ['indent', 'sort_keys', 'separators', 'ensure_ascii']
+        for key in json_kwarg_names:
+            if key in model_dump_kwargs:
+                json_kwargs[key] = model_dump_kwargs.pop(key)
+        # Get dict with Pydantic's processing (exclude_none, etc.)
+        data = super().model_dump(*args, **model_dump_kwargs)
+        data = self._post_process(data)
+        # Format timestamp as UTC RFC3339 string
+        if "timestamp" in data and isinstance(data["timestamp"], datetime):
+            utc_dt = data["timestamp"].astimezone(timezone.utc)
+            data["timestamp"] = utc_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return json.dumps(data, **json_kwargs)
 
 def main() -> None:
     print(


### PR DESCRIPTION
Added extension methods to support export of SSVC Selection data into schema supported format.

This pull request introduces enhancements to the serialization logic for selection models in `src/ssvc/selection.py`. The changes ensure that dumped data is consistently formatted, with empty or invalid values removed and timestamps properly formatted in JSON outputs.

Key improvements to serialization and data cleanup:

* Added a `_post_process` method to ensure all `Selection.values` are lists, remove empty or falsy items, and clean up empty array fields from the top-level dictionary.
* Overrode the `model_dump` and `model_dump_json` methods to apply the post-processing step before returning data, and to format timestamps as UTC RFC3339 strings in JSON output.