### PR TITLE
Removed debug print statement

### DIFF
--- a/src/ssvc/selection.py
+++ b/src/ssvc/selection.py
@@ -318,7 +318,6 @@ class SelectionList(_SchemaVersioned, _Timestamped, BaseModel):
         """
         for x in list(data.keys()):
             if not data[x]:
-                print(x)
                 del data[x]
         return data
 


### PR DESCRIPTION
Looks like a silly bug that I left out the print(x) statement. Should be removed.

This pull request makes a small change to the `_post_process` method in `src/ssvc/selection.py`, removing an unnecessary `print` statement that was used for debugging purposes.