### PR TITLE
Truncate long labels in decision table visualization

### DIFF
--- a/docs/ssvc-explorer/simple.js
+++ b/docs/ssvc-explorer/simple.js
@@ -151,8 +151,8 @@ const graphModule = (function() {
             if(/\s+$/.test(truncated) || /^\s/.test(dstr[18])) {
 		/* If it ends with spaces remove all spaces and the last
 		   non-space character to show the word has been truncated */
-		truncated = truncated.replace(/\s+$/, "");
-		truncated = truncated.slice(0, -1);
+							truncated = truncated.replace(/\s+$/, "");
+							truncated = truncated.slice(0, -1);
             }
             dstr = truncated + "...";
 	}


### PR DESCRIPTION
A small update to try to fix any text that is too long for display inside a SVG. It is quite simple first step to avoid SVG Graph looking too crowded.

This pull request enhances the visualization in `docs/ssvc-explorer/simple.js` by improving how node labels are displayed and ensuring class names are generated safely. The changes focus on truncating long node names for better readability and sanitizing class names to avoid issues with invalid characters.

Improvements to node label display:

* Added a `truncateEllipsis` function to shorten node names longer than 25 characters, appending an ellipsis for clarity. This function is now used wherever node names are displayed, improving readability in the graph. [[1]](diffhunk://#diff-44519492f9d8ff248b3f98891b09967ad7967c11d1f83a6b63c7abc54ec0f75dL147-R152) [[2]](diffhunk://#diff-44519492f9d8ff248b3f98891b09967ad7967c11d1f83a6b63c7abc54ec0f75dR206-R212) [[3]](diffhunk://#diff-44519492f9d8ff248b3f98891b09967ad7967c11d1f83a6b63c7abc54ec0f75dL371-R389)
* Node labels now include a `data-fullname` attribute containing the full, untruncated name, allowing access to the complete value if needed (e.g., for tooltips or accessibility). [[1]](diffhunk://#diff-44519492f9d8ff248b3f98891b09967ad7967c11d1f83a6b63c7abc54ec0f75dR206-R212) [[2]](diffhunk://#diff-44519492f9d8ff248b3f98891b09967ad7967c11d1f83a6b63c7abc54ec0f75dL371-R389)

Class name sanitization:

* Updated the logic for generating class names from node names to ensure they start with a letter and contain only safe characters, preventing potential CSS or JavaScript issues.