### PR TITLE
Change syntax of markdownlint ignores

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,5 @@
+ignores:
+  - .github/**
 default: true
 # disable noisy rules
 # 0004 Unordered List style
@@ -27,4 +29,3 @@ MD049:
 MD050:
   style: "asterisk"
 
-!*.github


### PR DESCRIPTION
This pull request updates the `.markdownlint.yml` configuration to improve how markdown linting is applied across the repository. The main change is to ignore markdown files inside the `.github` directory, ensuring that markdownlint does not process those files.

Markdownlint configuration updates:

* Added an `ignores` section to `.markdownlint.yml` to exclude all files under `.github/**` from linting.
* Removed the old ignore pattern for `.github` from the `MD049` section, consolidating ignores in the new `ignores` section.