### PR TITLE
Fix for prompting div location failure

### DIFF
--- a/docs/ssvc-explorer/index.md
+++ b/docs/ssvc-explorer/index.md
@@ -76,12 +76,11 @@ Language
 <button onclick="SSVC.updateTree()" data-update="1" style="margin-top: 10px;padding: 8px 12px;border: none;background-color: #007bff;color: #fff;border-radius: 4px;cursor: pointer; float:right">Update</button>
 <button onclick="SSVC.popupEnd()" style="margin: 10px 10px 0px 0px;;padding: 8px 12px;border: none;background-color: #ff2121;color: #fff;border-radius: 4px;cursor: pointer; float:right">Cancel</button>
 </div>
-</div>
-
 <div data-yesno="1" style="display:none">
 <h4 style="text-align: center">Would you like to proceed?</h4>
 <button style="margin-top: 10px;padding: 8px 12px;border: none;background-color: #007bff;color: #fff;border-radius: 4px;cursor: pointer; float:right">Yes</button>
 <button style="margin: 10px 10px 0px 0px;;padding: 8px 12px;border: none;background-color: #ff2121;color: #fff;border-radius: 4px;cursor: pointer; float:right">No</button>
+</div>
 </div>
 <form autocomplete="off">
 <span style="font-size: 20px;font-weight: bold; vertical-align:top">Sample Decision Models:</span>

--- a/docs/ssvc-explorer/simple.js
+++ b/docs/ssvc-explorer/simple.js
@@ -2627,6 +2627,7 @@ function fun_execute(w) {
     return {
 	ssvc_launch: ssvc_launch,
 	decision_trees: decision_trees,
+	decision_points, decision_points,
 	form: form,
 	loadSSVC: loadSSVC,
 	readFile: readFile,


### PR DESCRIPTION
Bug fix for #1055 - I think this fixes the issue. It is a simple DIV misplacement problem  that caused this. An update to include SSVC.decision_points as an anchor to collect DP's currently created is also added.   This pull request contains minor updates to the SSVC Explorer documentation and JavaScript code. The changes include a small fix to the HTML structure and an update to the returned object in the JavaScript module.

- Documentation/HTML structure:
  * Fixed the placement of a closing `</div>` tag in `index.md` to ensure proper HTML nesting and rendering.

- JavaScript module export:
  * Added `decision_points` to the returned object of the main function in `simple.js`, making this property accessible externally.

