### PR TITLE
revise topics/decision trees for decision tables terminology shift

### DIFF
--- a/docs/_includes/ADR0014.md
+++ b/docs/_includes/ADR0014.md
@@ -8,5 +8,4 @@
 
     Starting in SSVC v2025.9, we shifted to the term decision table to avoid
     confusion with the ML meaning. For more information, see
-    [ADR-0014](../../docs/adr/0014-use-decision-table-terminology.md).
-
+    [ADR-0014](../docs/adr/0014-use-decision-table-terminology.md).

--- a/docs/_includes/ADR0014.md
+++ b/docs/_includes/ADR0014.md
@@ -8,4 +8,4 @@
 
     Starting in SSVC v2025.9, we shifted to the term decision table to avoid
     confusion with the ML meaning. For more information, see
-    [ADR-0014](../docs/adr/0014-use-decision-table-terminology.md).
+    [ADR-0014](../adr/0014-use-decision-table-terminology.md).

--- a/docs/_includes/ADR0014.md
+++ b/docs/_includes/ADR0014.md
@@ -1,0 +1,12 @@
+!!! note inline end "About the term "decision tree""
+
+    In machine learning, a decision tree usually refers to a model learned from
+    data through statistical analysis. That’s not what SSVC uses the term for. In
+    the original SSVC documentation, decision tree referred to the
+    operations-research concept: a hand-crafted structure that encodes deliberate
+    choices, not a model inferred from datasets.
+
+    Starting in SSVC v2025.9, we shifted to the term decision table to avoid
+    confusion with the ML meaning. For more information, see
+    [ADR-0014](../../docs/adr/0014-decision-tree-vs-decision-table.md).
+

--- a/docs/_includes/ADR0014.md
+++ b/docs/_includes/ADR0014.md
@@ -8,5 +8,5 @@
 
     Starting in SSVC v2025.9, we shifted to the term decision table to avoid
     confusion with the ML meaning. For more information, see
-    [ADR-0014](../../docs/adr/0014-decision-tree-vs-decision-table.md).
+    [ADR-0014](../../docs/adr/0014-use-decision-table-terminology.md).
 

--- a/docs/topics/decision_trees.md
+++ b/docs/topics/decision_trees.md
@@ -1,43 +1,78 @@
 # Decision Trees
 
-A decision tree is an acyclic structure where nodes represent aspects of the decision or relevant properties and branches represent possible options for each aspect or property.
-Each decision point can have two or more options.
+!!! note inline end "About the term "decision tree""
 
-Decision trees can be used to meet all of the design goals, even plural recommendations and transparent tree-construction processes.
-Decision trees support plural recommendations because a separate tree can represent each stakeholder group.
-The opportunity for transparency surfaces immediately: any deviation among the decision trees for different stakeholder groups should have a documented reason—supported by public evidence when possible—for the deviation.
-Transparency may be difficult to achieve, since each node in the tree and each of the values need to be explained and justified, but this cost is paid infrequently.
+    In machine learning, a decision tree usually refers to a model learned from
+    data through statistical analysis. That’s not what SSVC uses the term for. In
+    the original SSVC documentation, decision tree referred to the
+    operations-research concept: a hand-crafted structure that encodes deliberate
+    choices, not a model inferred from datasets.
 
-There has been limited but positive use of decision trees in vulnerability management.
-For example, Vulnerability Response Decision Assistance (VRDA) studies how to make decisions about how to respond to vulnerability reports [@manion2009vrda].
-This paper continues roughly in the vein of such work to construct multiple decision trees for prioritization within the vulnerability management process.
+    Starting in SSVC v2025.9, we shifted to the term decision table to avoid
+    confusion with the ML meaning. For more information, see
+    [ADR-0014](../../docs/adr/0014-decision-tree-vs-decision-table.md).
+
+A decision tree is an acyclic structure where nodes represent aspects of the
+decision or relevant properties and branches represent possible options for each
+aspect or property.  Each decision point can have two or more options.
+
+Decision trees can be used to meet all of the design goals, even plural
+recommendations and transparent tree-construction processes.  Decision trees
+support plural recommendations because a separate tree can represent each
+stakeholder group.  The opportunity for transparency surfaces immediately: any
+deviation among the decision trees for different stakeholder groups should have
+a documented reason—supported by public evidence when possible—for the
+deviation.  Transparency may be difficult to achieve, since each node in the
+tree and each of the values need to be explained and justified, but this cost is
+paid infrequently.
+
+There has been limited but positive use of decision trees in vulnerability
+management.  For example, Vulnerability Response Decision Assistance (VRDA)
+studies how to make decisions about how to respond to vulnerability reports
+[@manion2009vrda].  This paper continues roughly in the vein of such work to
+construct multiple decision trees for prioritization within the vulnerability
+management process.
 
 ## Representation choices
 
-A decision tree can represent the same content in different ways.
-Since a decision tree is a representation of logical relationships between qualitative variables, the equivalent content can be represented in other formats as well.
-The R package [data.tree](https://cran.r-project.org/web/packages/data.tree/data.tree.pdf) has a variety of both internal representations and visualizations.
+A decision tree can represent the same content in different ways.  Since a
+decision tree is a representation of logical relationships between qualitative
+variables, the equivalent content can be represented in other formats as well.
+The R package
+[data.tree](https://cran.r-project.org/web/packages/data.tree/data.tree.pdf) has
+a variety of both internal representations and visualizations.
 
-For data input, we elected to keep SSVC simpler than R, and just use a CSV (or other fixed-delimiter separated file) as canonical data input.
-All visualizations of a tree should be built from a canonical CSV that defines the decisions for that stakeholder.
-Examples are located in [SSVC/data](https://github.com/CERTCC/SSVC/tree/main/data).
-An interoperable CSV format is also flexible enough to support a variety of uses.
-Every situation in SSVC is defined by the values for each decision point and the priority label (outcome) for that situation (as defined in [Likely Decision Points and Relevant Data](../reference/decision_points/index.md)).
-A CSV will typically be 30-100 rows that each look something like:
+For data input, we elected to keep SSVC simpler than R, and just use a CSV (or
+other fixed-delimiter separated file) as canonical data input.  All
+visualizations of a tree should be built from a canonical CSV that defines the
+decisions for that stakeholder.  Examples are located in
+[SSVC/data](https://github.com/CERTCC/SSVC/tree/main/data).  An interoperable
+CSV format is also flexible enough to support a variety of uses.  Every
+situation in SSVC is defined by the values for each decision point and the
+priority label (outcome) for that situation (as defined in [Likely Decision
+Points and Relevant Data](../reference/decision_points/index.md)).  A CSV will
+typically be 30-100 rows that each look something like:
 
 ```
 2,none,laborious,partial,significant,scheduled
 ```
 
-Where “2” is the row number, [*none*](../reference/decision_points/exploitation.md) through [*significant*](../reference/decision_points/public_safety_impact.md) are values for decision points, and *scheduled* is a priority label or outcome.
-Different stakeholders will have different decision points (and so different options for values) and different outcomes, but this is the basic shape of a CSV file to define SSVC stakeholder decisions.
+Where “2” is the row number,
+[*none*](../reference/decision_points/exploitation.md) through
+[*significant*](../reference/decision_points/public_safety_impact.md) are values
+for decision points, and *scheduled* is a priority label or outcome.  Different
+stakeholders will have different decision points (and so different options for
+values) and different outcomes, but this is the basic shape of a CSV file to
+define SSVC stakeholder decisions.
 
 ### Visualizing Decision Trees
 
-The tree visualization options are more diverse.
-We provide an example format, and codified it in [src/SSVC_csv-to-latex.py](https://github.com/CERTCC/SSVC/tree/main/src).
-Why have we gone to this trouble when (for example) the R data.tree package has a handy print-to-ASCII function?
-Because this function produces output like the following:
+The tree visualization options are more diverse.  We provide an example format,
+and codified it in
+[src/SSVC_csv-to-latex.py](https://github.com/CERTCC/SSVC/tree/main/src).  Why
+have we gone to this trouble when (for example) the R data.tree package has a
+handy print-to-ASCII function?  Because this function produces output like the
+following:
 
 ```
 1    start                                        
@@ -52,7 +87,9 @@ Because this function produces output like the following:
 35    ¦   ¦   ¦   ¦   ¦       ¦   ¦--A:H  Critical
 ```
 
-This sample is a snippet of the CVSS version 3.0 base scoring algorithm represented as a decision tree.
-The full tree can be found [here](cvss_full_tree.md).
-This tree representation is functional, but not as flexible or aesthetic as might be hoped.
-The visualizations provided by R are geared towards analysis of decision trees in a random forest ML model, rather than operations-research type trees.
+This sample is a snippet of the CVSS version 3.0 base scoring algorithm
+represented as a decision tree.  The full tree can be found
+[here](cvss_full_tree.md).  This tree representation is functional, but not as
+flexible or aesthetic as might be hoped.  The visualizations provided by R are
+geared towards analysis of decision trees in a random forest ML model, rather
+than operations-research type trees.

--- a/docs/topics/decision_trees.md
+++ b/docs/topics/decision_trees.md
@@ -1,16 +1,6 @@
 # Decision Trees
 
-!!! note inline end "About the term "decision tree""
-
-    In machine learning, a decision tree usually refers to a model learned from
-    data through statistical analysis. That’s not what SSVC uses the term for. In
-    the original SSVC documentation, decision tree referred to the
-    operations-research concept: a hand-crafted structure that encodes deliberate
-    choices, not a model inferred from datasets.
-
-    Starting in SSVC v2025.9, we shifted to the term decision table to avoid
-    confusion with the ML meaning. For more information, see
-    [ADR-0014](../../docs/adr/0014-decision-tree-vs-decision-table.md).
+{% include-markdown "../_includes/ADR0014.md" %}
 
 A decision tree is an acyclic structure where nodes represent aspects of the
 decision or relevant properties and branches represent possible options for each

--- a/docs/topics/decision_trees.md
+++ b/docs/topics/decision_trees.md
@@ -19,7 +19,7 @@ paid infrequently.
 There has been limited but positive use of decision trees in vulnerability
 management.  For example, [Vulnerability Response Decision Assistance
 (VRDA)](https://www.sei.cmu.edu/library/effectiveness-of-the-vulnerability-response-decision-assistance-vrda-framework)
-studies how to make decisions about how to respond to vulnerability reports .
+studies how to make decisions about how to respond to vulnerability reports.
 This paper continues roughly in the vein of such work to construct multiple
 decision trees for prioritization within the vulnerability management process.
 

--- a/docs/topics/decision_trees.md
+++ b/docs/topics/decision_trees.md
@@ -78,8 +78,8 @@ following:
 ```
 
 This sample is a snippet of the CVSS version 3.0 base scoring algorithm
-represented as a decision tree.  The full tree can be found
-[here](cvss_full_tree.md).  This tree representation is functional, but not as
-flexible or aesthetic as might be hoped.  The visualizations provided by R are
-geared towards analysis of decision trees in a random forest ML model, rather
-than operations-research type trees.
+represented as a decision tree.  [The full CVSS version 3.0 decision tree]
+(cvss_full_tree.md) shows the complete structure.  This tree representation is
+functional, but not as flexible or aesthetic as might be hoped.  The
+visualizations provided by R are geared towards analysis of decision trees in a
+random forest ML model, rather than operations-research type trees.

--- a/docs/topics/decision_trees.md
+++ b/docs/topics/decision_trees.md
@@ -27,11 +27,11 @@ tree and each of the values need to be explained and justified, but this cost is
 paid infrequently.
 
 There has been limited but positive use of decision trees in vulnerability
-management.  For example, Vulnerability Response Decision Assistance (VRDA)
-studies how to make decisions about how to respond to vulnerability reports
-[@manion2009vrda].  This paper continues roughly in the vein of such work to
-construct multiple decision trees for prioritization within the vulnerability
-management process.
+management.  For example, [Vulnerability Response Decision Assistance
+(VRDA)](https://www.sei.cmu.edu/library/effectiveness-of-the-vulnerability-response-decision-assistance-vrda-framework)
+studies how to make decisions about how to respond to vulnerability reports .
+This paper continues roughly in the vein of such work to construct multiple
+decision trees for prioritization within the vulnerability management process.
 
 ## Representation choices
 

--- a/docs/topics/formalization_options.md
+++ b/docs/topics/formalization_options.md
@@ -1,5 +1,7 @@
 # Formalization Options
 
+{% include-markdown "../_includes/ADR0014.md" %}
+
 This section briefly surveys the available formalization options against the six design goals described above.
 The table below summarizes the results.
 This survey is opportunistic; it is based on conversations with several experts and our professional experience.


### PR DESCRIPTION
This pull request updates the documentation for decision trees to clarify terminology and improve explanations, especially distinguishing between machine learning and operations-research meanings. It also enhances formatting and improves a reference link in the document.

**Terminology clarification and context:**
- Added an inline note at the top explaining that SSVC uses "decision tree" in the operations-research sense (hand-crafted choices), not the machine learning sense (statistically learned models), and notes the terminology shift to "decision table" in SSVC v2025.9 to reduce confusion. Includes a link to ADR-0014 for further details.

<img width="896" height="737" alt="image" src="https://github.com/user-attachments/assets/7aebe2d8-4d33-4ad7-970a-8e8839e14c14" />

**Documentation and formatting improvements:**
- Applied markdownlint
- Updated references to external resources, such as the VRDA framework and the R `data.tree` package, to use direct links and clearer descriptions.


**Markdownlint is unhappy about a few things:**
```
decision_trees.md:56 error MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
decision_trees.md:56 error MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
decision_trees.md:77 error MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
decision_trees.md:77 error MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
decision_trees.md:92:2 error MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
```

Resolves #990