### PR TITLE
Pypi release can be now automated.

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Verify distributions
         run: |
-          pip install -U twine
-          twine check dist/*
           ls -lah dist/
 
       - name: Upload distributions

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,9 +1,12 @@
+---
 name: Build and Publish to PyPI
 
 on:
   push:
     tags:
       - "20*"
+    branches:
+      - pypi
 
 permissions:
   contents: read
@@ -71,4 +74,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -5,8 +5,7 @@ on:
   push:
     tags:
       - "20*"
-    branches:
-      - pypi
+
 
 permissions:
   contents: read

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Verify distributions
         run: |
-          uv pip install twine
+          pip install twine
           twine check dist/*
           ls -lah dist/
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,74 @@
+name: Build and Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "20*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip build twine
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify distributions
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+          ls -lah dist/
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Verify distributions
         run: |
-          pip install twine
+          pip install -U twine
           twine check dist/*
           ls -lah dist/
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,4 +1,3 @@
----
 name: Build and Publish to PyPI
 
 on:
@@ -6,13 +5,12 @@ on:
     tags:
       - "20*"
 
-
 permissions:
   contents: read
 
 jobs:
   build:
-    name: Build distribution
+    name: Build distribution (uv)
     runs-on: ubuntu-latest
 
     steps:
@@ -21,21 +19,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
 
-      - name: Install build tooling
-        run: |
-          python -m pip install --upgrade pip build twine
+      - name: Set up Python (via uv)
+        run: uv python install 3.12
 
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Verify distributions
         run: |
-          python -m pip install --upgrade twine
+          uv pip install twine
           twine check dist/*
           ls -lah dist/
 
@@ -44,6 +39,7 @@ jobs:
         with:
           name: dist
           path: dist/*
+
   publish:
     name: Publish to PyPI
     needs: build

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -26,15 +26,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip build twine
-
-      - name: Sync dependencies
-        run: uv sync --frozen
 
       - name: Build package
         run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,11 @@ ssvc_doctools="ssvc.doctools:main"
 "Project" = "https://github.com/CERTCC/SSVC"
 "Bug Tracker" = "https://github.com/CERTCC/SSVC/issues"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
 [tool.setuptools.packages.find]
-where = ["."]  # list of folders that contain the packages (["."] by default)
+where = ["src"]  # list of folders that contain the packages (["."] by default)
 include = ["ssvc*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["test*"]  # exclude packages matching these glob patterns (empty by default)
 #namespaces = false  # to disable scanning PEP 420 namespaces (true by default)


### PR DESCRIPTION
Related to #1175  - The pypi branch requires that we modify pyproject.toml

To release a project to pypi
1. Ensure a Tag is created in claver like format currently `date +%Y.%-m.%-d%H%M` 
2. Push the updates to the branch pypi - then it will use OIDC authentication to publish the software to pypi


@ahouseholder - please make sure the pyproject.toml changes are okay with you. This is required to ensure that pypi package grabs the required files from "src/" directory.

