### PR TITLE
A public event is needed after main has been updated and the version number has been moved

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Verify distributions
         run: |
-          pip install -U twine
-          twine check dist/*
           ls -lah dist/
 
       - name: Upload distributions

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,9 +1,12 @@
+---
 name: Build and Publish to PyPI
 
 on:
   push:
     tags:
       - "20*"
+    branches:
+      - pypi
 
 permissions:
   contents: read
@@ -71,4 +74,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -5,8 +5,7 @@ on:
   push:
     tags:
       - "20*"
-    branches:
-      - pypi
+
 
 permissions:
   contents: read

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Verify distributions
         run: |
-          uv pip install twine
+          pip install twine
           twine check dist/*
           ls -lah dist/
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,74 @@
+name: Build and Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "20*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip build twine
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify distributions
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+          ls -lah dist/
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Verify distributions
         run: |
-          pip install twine
+          pip install -U twine
           twine check dist/*
           ls -lah dist/
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,4 +1,3 @@
----
 name: Build and Publish to PyPI
 
 on:
@@ -6,13 +5,12 @@ on:
     tags:
       - "20*"
 
-
 permissions:
   contents: read
 
 jobs:
   build:
-    name: Build distribution
+    name: Build distribution (uv)
     runs-on: ubuntu-latest
 
     steps:
@@ -21,21 +19,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
 
-      - name: Install build tooling
-        run: |
-          python -m pip install --upgrade pip build twine
+      - name: Set up Python (via uv)
+        run: uv python install 3.12
 
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Verify distributions
         run: |
-          python -m pip install --upgrade twine
+          uv pip install twine
           twine check dist/*
           ls -lah dist/
 
@@ -44,6 +39,7 @@ jobs:
         with:
           name: dist
           path: dist/*
+
   publish:
     name: Publish to PyPI
     needs: build

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -26,15 +26,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip build twine
-
-      - name: Sync dependencies
-        run: uv sync --frozen
 
       - name: Build package
         run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,11 @@ ssvc_doctools="ssvc.doctools:main"
 "Project" = "https://github.com/CERTCC/SSVC"
 "Bug Tracker" = "https://github.com/CERTCC/SSVC/issues"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
 [tool.setuptools.packages.find]
-where = ["."]  # list of folders that contain the packages (["."] by default)
+where = ["src"]  # list of folders that contain the packages (["."] by default)
 include = ["ssvc*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["test*"]  # exclude packages matching these glob patterns (empty by default)
 #namespaces = false  # to disable scanning PEP 420 namespaces (true by default)

--- a/uv.lock
+++ b/uv.lock
@@ -1294,7 +1294,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1303,9 +1303,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for building and publishing the package to PyPI, and updates the `pyproject.toml` configuration to support a `src`-based project layout. These changes improve the project's packaging and release process, ensuring that distributions are built and published in a consistent, automated manner.

**CI/CD: PyPI Publishing Workflow**
* Added a new GitHub Actions workflow `.github/workflows/pypi_publish.yml` to automate building and publishing the package to PyPI when a tag starting with `20` is pushed. The workflow uses `uv` for building distributions and securely uploads artifacts and publishes them to PyPI.

**Packaging Configuration**
* Updated `pyproject.toml` to use a `src`-based layout by specifying `package-dir = {"" = "src"}` and changing the `where` parameter to `["src"]` for package discovery. This ensures that only packages under the `src` directory are included in builds.

**Version Numbering**
The new version numbering will remove`v` in the beginning so the new version on the website will should like `2026.6.221553`
