### PR TITLE
Make ascii_tree's optional df argument usable, and stop it mutating the caller's frame

### DIFF
--- a/src/ssvc/decision_tables/helpers.py
+++ b/src/ssvc/decision_tables/helpers.py
@@ -377,11 +377,13 @@ def ascii_tree(dt: DecisionTable, df: pd.DataFrame | None = None) -> str:
     Reads a Pandas data frame, builds a decision tree, and returns its ASCII representation.
     """
     # Check for the optional 'row' column and drop it if it exists.
-    if df == None:
+    if df is None:
         df = decision_table_to_longform_df(dt)
 
     if "row" in df.columns:
-        df.drop(columns="row", inplace=True)
+        # Not in place: df may belong to the caller, and dropping a column from
+        # under them is not something a read-only rendering helper should do.
+        df = df.drop(columns="row")
 
     # Separate feature columns from the outcome column.
     feature_cols = list(df.columns[:-1])

--- a/src/test/decision_tables/test_helpers.py
+++ b/src/test/decision_tables/test_helpers.py
@@ -1,0 +1,74 @@
+#  Copyright (c) 2026 Carnegie Mellon University.
+#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE
+#  ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+#  CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND,
+#  EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT
+#  NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR
+#  MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE
+#  OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE
+#  ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM
+#  PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#  Licensed under a MIT (SEI)-style license, please see LICENSE or contact
+#  permission@sei.cmu.edu for full terms.
+#  [DISTRIBUTION STATEMENT A] This material has been approved for
+#  public release and unlimited distribution. Please see Copyright notice
+#  for non-US Government use and distribution.
+#  This Software includes and/or makes use of Third-Party Software each
+#  subject to its own license.
+#  DM24-0278
+import unittest
+
+from ssvc.decision_tables.base import ascii_tree as base_ascii_tree
+from ssvc.decision_tables.example.to_play import LATEST as EXAMPLE_DT
+from ssvc.decision_tables.helpers import (
+    ascii_tree,
+    decision_table_to_longform_df,
+)
+
+
+class TestAsciiTree(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dt = EXAMPLE_DT
+
+    def test_df_omitted(self) -> None:
+        # The path every caller in the repository takes.
+        self.assertGreater(len(ascii_tree(self.dt).splitlines()), 0)
+
+    def test_df_supplied(self) -> None:
+        # Passing the frame is what the signature invites, and `df == None`
+        # made it raise ValueError from DataFrame.__bool__ for every frame.
+        df = decision_table_to_longform_df(self.dt)
+        self.assertEqual(ascii_tree(self.dt, df), ascii_tree(self.dt))
+
+    def test_df_supplied_via_base(self) -> None:
+        # base re-exports the helper, so the same call has two public routes.
+        df = decision_table_to_longform_df(self.dt)
+        self.assertEqual(
+            base_ascii_tree(self.dt, df), base_ascii_tree(self.dt)
+        )
+
+    def test_caller_frame_is_not_modified(self) -> None:
+        # The "row" column was dropped in place. That only ever touched the
+        # frame this function built itself while `df` could not be supplied;
+        # once it can, an in-place drop takes a column off the caller's object.
+        df = decision_table_to_longform_df(self.dt)
+        df.insert(0, "row", range(len(df)))
+        columns_before = list(df.columns)
+
+        ascii_tree(self.dt, df)
+
+        self.assertEqual(list(df.columns), columns_before)
+
+    def test_row_column_is_excluded_from_the_tree(self) -> None:
+        # Dropping "row" must still happen, just not on the caller's frame.
+        df = decision_table_to_longform_df(self.dt)
+        without_row = ascii_tree(self.dt, df)
+
+        df_with_row = decision_table_to_longform_df(self.dt)
+        df_with_row.insert(0, "row", range(len(df_with_row)))
+
+        self.assertEqual(ascii_tree(self.dt, df_with_row), without_row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- resolves #1224

## What was wrong

`ascii_tree(dt, df)` raised `ValueError` for every non-`None` `df`, so the optional second parameter in its own signature could never be used.

`helpers.py:380` tested the sentinel with `==`:

```python
def ascii_tree(dt: DecisionTable, df: pd.DataFrame | None = None) -> str:
    if df == None:
        df = decision_table_to_longform_df(dt)
```

On a DataFrame `==` is elementwise, so it returns a same-shaped boolean frame and the enclosing `if` calls `DataFrame.__bool__`, which pandas raises from by design. The default path survived only because `None == None` is a plain scalar `True`. Every caller in the repository and both README examples omit `df`, which is why nothing ever exercised it. `base.py:706` re-exports the function, so both public routes failed the same way.

## What changed

Two lines.

**`if df == None:` becomes `if df is None:`.** The parameter is documented as `pd.DataFrame | None` and the sentinel is identity, so `is` is the right test rather than `isinstance`.

**The `"row"` column is no longer dropped in place.** This is the part I would most like a second opinion on, because it is not in the issue.

The in-place drop was harmless only while `df` could not be supplied: the frame always belonged to this function. Making the argument work makes the mutation reachable. A caller who passes a frame carrying a `"row"` column silently loses that column from their own object. Measured on unmodified code, with the `is None` fix applied so the call could proceed at all:

```
caller df columns before: ['row', 'example:W:1.0.0', 'example:H:1.0.0', 'basic:YN:1.0.0']
caller df columns after : ['example:W:1.0.0', 'example:H:1.0.0', 'basic:YN:1.0.0']
```

`df = df.drop(columns="row")` keeps the column out of the tree while leaving the caller's object alone. If you would rather keep the in-place drop and document the mutation instead, that is a reasonable call and I will split it out.

## Tests

`ascii_tree` had no test coverage, so this adds `src/test/decision_tables/test_helpers.py` with five tests:

| test | on unmodified `main` |
| --- | --- |
| `test_df_omitted` | passes |
| `test_df_supplied` | fails |
| `test_df_supplied_via_base` | fails |
| `test_caller_frame_is_not_modified` | fails |
| `test_row_column_is_excluded_from_the_tree` | fails |

The first is deliberate: it covers the path every current caller takes and passes either way, so it demonstrates the fixture and the suite is not vacuous. The other four fail before and pass after, confirmed by stashing the change and re-running.

`src/test` has the same single pre-existing failure before and after this branch, `test_main.py::MyTestCase::test_expected_routers`, which is unrelated.

`black --check` is clean on the new test file. I left `helpers.py` formatting alone: it does not satisfy `black` on `main` either, the diff `black` wants is in the HTML block well away from this change, and the `psf/black` step in `python-app.yml` is commented out, so reformatting it here would be unrelated churn.