### PR TITLE
fix: use identity check for None in ascii_tree

### DIFF
--- a/src/ssvc/decision_tables/helpers.py
+++ b/src/ssvc/decision_tables/helpers.py
@@ -377,7 +377,7 @@ def ascii_tree(dt: DecisionTable, df: pd.DataFrame | None = None) -> str:
     Reads a Pandas data frame, builds a decision tree, and returns its ASCII representation.
     """
     # Check for the optional 'row' column and drop it if it exists.
-    if df == None:
+    if df is None:
         df = decision_table_to_longform_df(dt)
 
     if "row" in df.columns:


### PR DESCRIPTION
## Summary
Fix `ascii_tree` raising `ValueError` when a DataFrame is supplied as the `df` parameter.

The function checked `if df == None`, which is elementwise comparison for DataFrames, causing pandas to raise `ValueError: The truth value of a DataFrame is ambiguous`. This changes the check to `if df is None`, which correctly checks for `None` and allows using a caller-provided DataFrame.

Closes #1224.

## Testing
- Verified with `ascii_tree(DT)` (default path) still works.
- Verified with `ascii_tree(DT, df)` now uses the provided DataFrame and no longer raises.
