### PR TITLE
Fix namespace ABNF

### DIFF
--- a/src/ssvc/utils/namespace_patterns.py
+++ b/src/ssvc/utils/namespace_patterns.py
@@ -38,8 +38,8 @@ bcp47 = (
     '(([a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){0,2})?|[a-z'
     'A-Z]{4,8})(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-'
     f'(({alnum}){{5,8}}|[0-9]({alnum}){{3}}))*(-{singleton}(-'
-    f'({alnum}){{2,8}})+)*(-[xX](-({alnum}){{2,8}})+)?|[xX](-'
-    f'({alnum}){{2,8}})+|i-default|i-mingo)'
+    f'({alnum}){{2,8}})+)*(-[xX](-({alnum}){{1,8}})+)?|[xX](-'
+    f'({alnum}){{1,8}})+|i-default|i-mingo)'
 )
 translation = f'\\.({reverse_dns}|{x_name})\\${bcp47}'
 ext_seg = f'({bcp47}|\\.{x_name}|{translation})'

--- a/src/ssvc/utils/ssvc_namespace_pattern.abnf
+++ b/src/ssvc/utils/ssvc_namespace_pattern.abnf
@@ -49,8 +49,8 @@ bcp47 = ( 2*3ALPHA
         [ "-" ( 2ALPHA / 3DIGIT ) ]
         *( "-" ( 5*8ALNUM / (DIGIT 3ALNUM) ) )
         *( "-"  singleton 1*( "-" 2*8ALNUM ) )
-        [ "-" "x" 1*( "-" 2*8ALNUM ) ]
-      / "x" 1*( "-" 2*8ALNUM )
+        [ "-" "x" 1*( "-" 1*8ALNUM ) ]
+      / "x" 1*( "-" 1*8ALNUM )
       / "i-default"
       / "i-mingo"
 


### PR DESCRIPTION
  remove typo in the expansion of `privateuse` from RFC5646.

  add the result of the Makefile run

resolve #1239