### PR TITLE
Added generatedAt field to SsvcObjectRegistry

### DIFF
--- a/data/json/ssvc_object_registry.json
+++ b/data/json/ssvc_object_registry.json
@@ -2,7 +2,7 @@
   "name": "SSVC Object Registry",
   "definition": "A registry for SSVC objects organized by type, namespace, key, and version.",
   "schemaVersion": "2.0.0",
-  "generatedAt": "2026-09-09T15:00:54.967443Z",
+  "generatedAt": "2026-09-09T15:10:13.388981Z",
   "types": {
     "DecisionPoint": {
       "type": "DecisionPoint",

--- a/data/json/ssvc_object_registry.json
+++ b/data/json/ssvc_object_registry.json
@@ -2,6 +2,7 @@
   "name": "SSVC Object Registry",
   "definition": "A registry for SSVC objects organized by type, namespace, key, and version.",
   "schemaVersion": "2.0.0",
+  "generatedAt": "2026-09-09T15:00:54.967443Z",
   "types": {
     "DecisionPoint": {
       "type": "DecisionPoint",

--- a/data/schema/v2/SsvcObjectRegistry_2_0_0.schema.json
+++ b/data/schema/v2/SsvcObjectRegistry_2_0_0.schema.json
@@ -371,8 +371,9 @@
     "generatedAt": {
       "title": "Generatedat",
       "description": "RFC 3339 timestamp indicating when the registry was generated.",
+      "format": "date-time",
       "type": "string"
-    },
+    }
     "types": {
       "title": "Types",
       "additionalProperties": {

--- a/data/schema/v2/SsvcObjectRegistry_2_0_0.schema.json
+++ b/data/schema/v2/SsvcObjectRegistry_2_0_0.schema.json
@@ -368,6 +368,11 @@
       "description": "The schema version of this selection list.",
       "type": "string"
     },
+    "generatedAt": {
+      "title": "Generatedat",
+      "description": "RFC 3339 timestamp indicating when the registry was generated.",
+      "type": "string"
+    },
     "types": {
       "title": "Types",
       "additionalProperties": {

--- a/data/schema/v2/SsvcObjectRegistry_2_0_0.schema.json
+++ b/data/schema/v2/SsvcObjectRegistry_2_0_0.schema.json
@@ -373,7 +373,7 @@
       "description": "RFC 3339 timestamp indicating when the registry was generated.",
       "format": "date-time",
       "type": "string"
-    }
+    },
     "types": {
       "title": "Types",
       "additionalProperties": {

--- a/src/ssvc/registry/base.py
+++ b/src/ssvc/registry/base.py
@@ -141,7 +141,13 @@ class SsvcObjectRegistry(_SchemaVersioned, _Base, BaseModel):
     generatedAt: str = Field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         description="RFC 3339 timestamp indicating when the registry was generated.",
+        json_schema_extra={"format": "date-time"},
     )
+
+    def model_dump_json(self, *args, **kwargs) -> str:
+        # Refresh at serialization time so singleton registries record actual generation time.
+        self.generatedAt = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        return super().model_dump_json(*args, **kwargs)
     schemaVersion: Literal[SCHEMA_VERSION] = Field(
         ...,
         description="The schema version of this selection list.",

--- a/src/ssvc/registry/base.py
+++ b/src/ssvc/registry/base.py
@@ -22,6 +22,7 @@ Work in progress on an experimental registry object for SSVC.
 #  DM24-0278
 
 import logging
+from datetime import datetime, timezone
 from typing import Any, ClassVar, Literal, Optional, Union
 
 import semver
@@ -137,6 +138,10 @@ class _NsType(BaseModel):
 
 class SsvcObjectRegistry(_SchemaVersioned, _Base, BaseModel):
     _schema_version: ClassVar[str] = SCHEMA_VERSION
+    generatedAt: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        description="RFC 3339 timestamp indicating when the registry was generated.",
+    )
     schemaVersion: Literal[SCHEMA_VERSION] = Field(
         ...,
         description="The schema version of this selection list.",


### PR DESCRIPTION
This pull request introduces a new timestamp field to the `SsvcObjectRegistry` class to record when the registry was generated. This helps track the creation time of registry data in a standardized format.

Enhancement to registry metadata:

* Added a `generatedAt` field to the `SsvcObjectRegistry` class, which automatically sets an RFC 3339-compliant UTC timestamp when the registry is generated.
* Imported `datetime` and `timezone` from the standard library to support timestamp generation.

Attempt to resolve #1219 with a feature that will provide timestamp of the latest release of SSVC objects.
